### PR TITLE
Formatters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,9 @@ repos:
       - id: end-of-file-fixer
       - id: requirements-txt-fixer
       - id: trailing-whitespace
+
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
 
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
     -   id: black
 
@@ -15,12 +15,12 @@ repos:
             - pep8-naming==0.13.0
 
 -   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.1
+    rev: v2.0.0
     hooks:
     -   id: setup-cfg-fmt
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-json
         exclude: '^tests/invalid.json'

--- a/README.md
+++ b/README.md
@@ -253,6 +253,13 @@ Currently supported variables:
 * `{relative_root}`: The directory name of the .json config file. Think of this as the relative path
 `.` when using the command line, but this is a clear indication that it needs to be
 replaced with the dirname and not left alone.
+* `{ANYTHING!e}`: `!e` is a special conversion flag for Environment variables. This will
+be replaced with the correct shell environment variable. For bash it becomes `$ANYTHING`,
+in power shell `$env:ANYTHING`, and in command prompt `%ANYTHING%`. ANYTHING is the name
+of the environment variable.
+* `{;}`: This is replaced with the path separator for the shell. Ie `:` for bash, and `;`
+on windows(including bash).
+
 
 ### Defining Aliases
 

--- a/hab/__init__.py
+++ b/hab/__init__.py
@@ -10,17 +10,18 @@ __all__ = [
     'Solver',
 ]
 
-import anytree
 import glob
 import logging
 
+import anytree
+from packaging.requirements import Requirement
+
 from . import utils
-from .version import version as __version__
 from .errors import _IgnoredVersionError
-from .parsers import Config, HabBase, DistroVersion
+from .parsers import Config, DistroVersion, HabBase
 from .site import Site
 from .solvers import Solver
-from packaging.requirements import Requirement
+from .version import version as __version__
 
 logger = logging.getLogger(__name__)
 

--- a/hab/__main__.py
+++ b/hab/__main__.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 import sys
+
 import hab.cli
 
 if __name__ == "__main__":

--- a/hab/cli.py
+++ b/hab/cli.py
@@ -1,7 +1,9 @@
-import click
-from . import Resolver, Site
 import logging
 from pathlib import Path
+
+import click
+
+from . import Resolver, Site
 
 logger = logging.getLogger(__name__)
 

--- a/hab/formatter.py
+++ b/hab/formatter.py
@@ -1,0 +1,106 @@
+import string
+import sys
+
+
+class Formatter(string.Formatter):
+    """A extended string formatter class to parse habitat configurations.
+
+    Adds support for the "!e" conversion flag. This will fill in the key as a properly
+    formatted environment variable specifier. For example ''{PATH!e}'' will be converted
+    to ``$PATH`` for the sh language, and ``%env:PATH`` for the ps language.
+
+    This also converts ``{;}`` to the language specific path separator for environment
+    variables. On linux this is ``:`` on windows(even in bash) this is ``;``.
+
+    You need to specify the desired language when initializing this class. This can be
+    one of the supported language keys in ''Formatter.shell_formats'', or you can pass
+    a file extension supported by `Formatter.language_from_ext`. If you pass None, it
+    will preserve the formatting markers so it can be converted later.
+    """
+
+    shell_formats = {
+        # Command Prompt
+        'batch': {
+            'env_var': '%{}%',
+            ';': ';',
+        },
+        # Power Shell
+        'ps': {
+            'env_var': '$env:{}',
+            ';': ';',
+        },
+        # Using bash on linux
+        'sh': {
+            'env_var': '${}',
+            ';': ':',
+        },
+        # Using bash on windows
+        'shwin': {
+            'env_var': '${}',
+            ';': ';',
+        },
+        # Delay the format for future calls. This allows us to process the environment
+        # without changing these, and then when write_script is called the target
+        # scripting language is resolved.
+        None: {
+            'env_var': '{{{}!e}}',
+            ';': '{;}',
+        },
+    }
+
+    def __init__(self, language):
+        super(Formatter, self).__init__()
+        self.language = self.language_from_ext(language)
+        self.current_field_name = None
+
+    def convert_field(self, value, conversion):
+        if conversion == 'e':
+            return self.shell_formats[self.language]['env_var'].format(
+                self.current_field_name
+            )
+        else:
+            ret = super(Formatter, self).convert_field(value, conversion)
+        return ret
+
+    def get_field(self, field_name, args, kwargs):
+        self.current_field_name = field_name
+        ret = super(Formatter, self).get_field(field_name, args, kwargs)
+        return ret
+
+    @classmethod
+    def language_from_ext(cls, ext):
+        """Turn the provided file ext into the common name for that language.
+        This can be used to find the correct data for the cls.shell_formats mapping.
+
+        ".bat" and ".cmd" return "batch". ".ps1" returns "ps". ".sh" or an empty
+        string return "sh" if on linux and "shwin" if on windows. If `None` is passed
+        the format will be replaced with the same format command so future format
+        calls can re-apply the changes. Any other value passed is returned unmodified.
+        """
+        if ext in (".bat", ".cmd"):
+            return "batch"
+        elif ext == ".ps1":
+            return "ps"
+        elif ext in (".sh", ""):
+            # Assume no ext is a .sh file
+            if sys.platform == "win32":
+                return "shwin"
+            else:
+                return "sh"
+        return ext
+
+    def merge_kwargs(self, kwargs):
+        """Merge the provided kwargs on top of the current language's shell_formats
+        dict. This makes it so the default format options are added by default, but
+        still allows us to override them if required
+        """
+        ret = dict(self.shell_formats[self.language], **kwargs)
+        import os
+
+        ret = dict(os.environ, **ret)
+        return ret
+
+    def vformat(self, format_string, args, kwargs):
+        kwargs = self.merge_kwargs(kwargs)
+        ret = super(Formatter, self).vformat(format_string, args, kwargs)
+        return ret

--- a/hab/merge_dict.py
+++ b/hab/merge_dict.py
@@ -1,4 +1,5 @@
 import os
+
 from . import utils
 
 

--- a/hab/parsers/__init__.py
+++ b/hab/parsers/__init__.py
@@ -1,13 +1,12 @@
 from __future__ import print_function
 
-from .meta import hab_property, HabMeta, NotSet
-from .hab_base import HabBase
-from .placeholder import Placeholder
+from .config import Config
 from .distro import Distro
 from .distro_version import DistroVersion
-from .config import Config
 from .flat_config import FlatConfig
-
+from .hab_base import HabBase
+from .meta import HabMeta, NotSet, hab_property
+from .placeholder import Placeholder
 
 __all__ = [
     'Config',

--- a/hab/parsers/config.py
+++ b/hab/parsers/config.py
@@ -1,4 +1,5 @@
-from . import HabBase, NotSet, hab_property
+from .hab_base import HabBase
+from .meta import NotSet, hab_property
 
 
 class Config(HabBase):

--- a/hab/parsers/distro.py
+++ b/hab/parsers/distro.py
@@ -1,6 +1,7 @@
-from . import HabBase
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
+
+from .hab_base import HabBase
 
 
 class Distro(HabBase):

--- a/hab/parsers/distro.py
+++ b/hab/parsers/distro.py
@@ -12,7 +12,10 @@ class Distro(HabBase):
         try:
             version = max(versions)
         except ValueError:
-            raise Exception('Unable to find a valid version for "{}"'.format(specifier))
+            raise Exception(
+                f'Unable to find a valid version for "{specifier}" in versions '
+                f'[{", ".join([str(v) for v in self.versions.keys()])}]'
+            ) from None
         return self.versions[version]
 
     def matching_versions(self, specification):

--- a/hab/parsers/distro_version.py
+++ b/hab/parsers/distro_version.py
@@ -58,7 +58,7 @@ class DistroVersion(HabBase):
                             'Skipping "{}" its dirname is in the ignored list.'.format(
                                 filename
                             )
-                        )
+                        ) from None
                     raise LookupError(
                         'Hab was unable to determine the version for "{filename}".\n'
                         "The version is defined in one of several ways checked in this order:\n"
@@ -70,7 +70,7 @@ class DistroVersion(HabBase):
                         "preferred method for developers working copies.".format(
                             filename=self.filename
                         )
-                    )
+                    ) from None
 
         # The name should be the version == specifier.
         self.distro_name = data.get("name")

--- a/hab/parsers/distro_version.py
+++ b/hab/parsers/distro_version.py
@@ -1,6 +1,9 @@
-from . import HabBase, Distro, NotSet, hab_property
+from packaging.version import InvalidVersion, Version
+
 from ..errors import _IgnoredVersionError
-from packaging.version import Version, InvalidVersion
+from .distro import Distro
+from .hab_base import HabBase
+from .meta import NotSet, hab_property
 
 
 class DistroVersion(HabBase):

--- a/hab/parsers/flat_config.py
+++ b/hab/parsers/flat_config.py
@@ -1,7 +1,7 @@
 import logging
 
-from . import NotSet, hab_property
 from .config import Config
+from .meta import NotSet, hab_property
 
 logger = logging.getLogger(__name__)
 

--- a/hab/parsers/flat_config.py
+++ b/hab/parsers/flat_config.py
@@ -30,7 +30,8 @@ class FlatConfig(Config):
             self._properties, key=lambda i: self._properties[i].sort_key()
         ):
             if attrname == "uri":
-                # TODO: Add detection of setters to HabProperty and don't set values without setters
+                # TODO: Add detection of setters to HabProperty and don't set
+                # values without setters
                 # There is no setter for uri, setting it now will cause errors in testing
                 continue
             if getattr(self, attrname) != NotSet:

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -1,22 +1,22 @@
 from __future__ import print_function
-import anytree
+
 import logging
 import os
 import subprocess
 import sys
+from pathlib import Path
 
+import anytree
 import colorama
 from future.utils import with_metaclass
 from packaging.version import Version
-from pathlib import Path
 
-from . import HabMeta, NotSet, hab_property
-from ..formatter import Formatter
 from .. import utils
 from ..errors import DuplicateJsonError
+from ..formatter import Formatter
 from ..site import MergeDict
 from ..solvers import Solver
-
+from .meta import HabMeta, NotSet, hab_property
 
 logger = logging.getLogger(__name__)
 

--- a/hab/parsers/meta.py
+++ b/hab/parsers/meta.py
@@ -61,7 +61,7 @@ def hab_property(verbosity=0, group=1, process_order=100):
 class HabMeta(type):
     """Scans for HabProperties and adds their name to the `_properties` dict."""
 
-    def __new__(cls, name, bases, dct):
+    def __new__(cls, name, bases, dct):  # noqa: B902
         desc = {}
         # Include any _properties that are added by base classes we are inheriting.
         for base in bases:

--- a/hab/solvers.py
+++ b/hab/solvers.py
@@ -166,7 +166,7 @@ class Solver(object):
                 if self.redirects_required >= self.max_redirects:
                     raise MaxRedirectError(
                         "Redirect limit of {} reached".format(self.max_redirects)
-                    )
+                    ) from None
 
     @classmethod
     def simplify_requirements(cls, requirements):

--- a/hab/solvers.py
+++ b/hab/solvers.py
@@ -1,8 +1,11 @@
 from __future__ import print_function
-from copy import copy
+
 import logging
-from .errors import MaxRedirectError
+from copy import copy
+
 from packaging.requirements import Requirement
+
+from .errors import MaxRedirectError
 
 logger = logging.getLogger(__name__)
 

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -2,9 +2,10 @@ import errno
 import os
 import sys
 import textwrap
-from pathlib import Path
 from collections import UserDict
 from collections.abc import KeysView
+from pathlib import Path
+
 import colorama
 
 # Attempt to use pyjson5 if its installed, this allows us to add comments

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 platform = any

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,8 @@ select = B, C, E, F, N, W, B9
 extend-ignore =
     E203,
     E501,
-    E722
+    E722,
+    W503,
 max-line-length = 88
 exclude =
     *.egg-info

--- a/test.py
+++ b/test.py
@@ -1,6 +1,7 @@
 import logging
-from hab.site import Site
 from pprint import pprint
+
+from hab.site import Site
 
 logging.basicConfig()
 logging.getLogger('hab.parsers.site').setLevel(logging.DEBUG)

--- a/tests/configs/not_set/child.json
+++ b/tests/configs/not_set/child.json
@@ -6,7 +6,8 @@
             "UNSET_VARIABLE"
         ],
         "set": {
-            "TEST": "case"
+            "TEST": "case",
+            "FMT_FOR_OS": "a{;}b;c:{PATH!e}{;}d"
         }
     },
     "inherits": true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 import os
-import pytest
-
 from contextlib import contextmanager
 from pathlib import Path
-from hab import Resolver, Site
+
+import pytest
 from packaging.requirements import Requirement
+
+from hab import Resolver, Site
 
 
 @pytest.fixture

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,4 +1,5 @@
 import sys
+
 from hab.formatter import Formatter
 from hab.parsers import Config
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,52 @@
+import sys
+from hab.formatter import Formatter
+from hab.parsers import Config
+
+
+def test_e_format():
+    assert Formatter('sh').format('-{PATH!e}-') == '-$PATH-'
+    assert Formatter('sh').format('-{;}-') == '-:-'
+    # Bash formatting is different on windows for env vars
+    assert Formatter('shwin').format('-{PATH!e}-') == '-$PATH-'
+    assert Formatter('shwin').format('-{;}-') == '-;-'
+
+    assert Formatter('ps').format('-{PATH!e}-') == '-$env:PATH-'
+    assert Formatter('ps').format('-{;}-') == '-;-'
+
+    assert Formatter('batch').format('-{PATH!e}-') == '-%PATH%-'
+    assert Formatter('batch').format('-{;}-') == '-;-'
+
+    assert Formatter(None).format('-{PATH!e}-') == '-{PATH!e}-'
+    assert Formatter(None).format('-{;}-') == '-{;}-'
+
+
+def test_language_from_ext(monkeypatch):
+    # Arbitrary values are not modified
+    assert Formatter.language_from_ext('.abc') == ".abc"
+    assert Formatter.language_from_ext('anything') == "anything"
+
+    # Test that known file exts are translated to the shell name
+    assert Formatter.language_from_ext('.bat') == "batch"
+    assert Formatter.language_from_ext('.cmd') == "batch"
+    assert Formatter.language_from_ext('.ps1') == "ps"
+
+    # Bash formatting is different on windows for env vars
+    with monkeypatch.context() as m:
+        m.setattr(sys, 'platform', "win32")
+        assert Formatter.language_from_ext('.sh') == "shwin"
+        assert Formatter.language_from_ext('') == "shwin"
+
+        m.setattr(sys, 'platform', "anything_else")
+        assert Formatter.language_from_ext('.sh') == "sh"
+        assert Formatter.language_from_ext('') == "sh"
+
+
+def test_format_environment_value(resolver):
+    forest = {}
+    config = Config(forest, resolver)
+
+    # test_format_environment_value doesn't replace the special formatters.
+    # This allows us to delay these formats to only when creating the final
+    # shell scripts, not the first time we evaluate environment variables.
+    value = 'a{;}b;c:{PATH!e}{;}d'
+    assert config.format_environment_value(value, ext=None) == value

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,13 +1,15 @@
-import anytree
-from hab import utils
-from hab.errors import DuplicateJsonError
-from hab.parsers import DistroVersion, Config, NotSet
 import json
 import ntpath
-from packaging.version import Version
-import pytest
 import re
 import sys
+
+import anytree
+import pytest
+from packaging.version import Version
+
+from hab import utils
+from hab.errors import DuplicateJsonError
+from hab.parsers import Config, DistroVersion, NotSet
 
 
 def test_distro_parse(config_root, resolver):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,10 +1,10 @@
-import anytree
 import os
-import pytest
-
 from collections import OrderedDict
-from packaging.requirements import Requirement
 from pathlib import Path
+
+import anytree
+import pytest
+from packaging.requirements import Requirement
 
 from hab import Resolver, Site, utils
 from hab.errors import MaxRedirectError

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -137,10 +137,11 @@ def test_reduced(resolver, helpers):
     # Not set on the child so should be NotSet(ie doesn't inherit from parent)
     assert cfg.distros == NotSet
     # Settings defined on the child
-    assert cfg.environment_config == {
-        u"set": {u"TEST": u"case"},
+    config_check = {
+        u"set": {u"TEST": u"case", "FMT_FOR_OS": "a{;}b;c:{PATH!e}{;}d"},
         u"unset": [u"UNSET_VARIABLE"],
     }
+    assert cfg.environment_config == config_check
     assert cfg.inherits is True
     assert cfg.name == "child"
 
@@ -149,10 +150,7 @@ def test_reduced(resolver, helpers):
     # Inherited from the parent
     helpers.assert_requirements_equal(reduced.distros, check)
     # Values defined on the child are preserved
-    assert reduced.environment_config == {
-        u"set": {u"TEST": u"case"},
-        u"unset": [u"UNSET_VARIABLE"],
-    }
+    assert reduced.environment_config == config_check
     assert reduced.inherits is True
     assert reduced.name == "child"
     assert reduced.uri == "not_set/child"

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,5 +1,6 @@
 import colorama
 import pytest
+
 from hab import Site, utils
 
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,6 +1,7 @@
 import pytest
-from hab.solvers import Solver
 from packaging.requirements import Requirement
+
+from hab.solvers import Solver
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [x] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
Makes it possible to generically specify environment variables to expand for all shell types. Currently if you wanted to prepend a path onto the PATH env var, it will only work for one shell type. The `os_specific` property lets you work around the difference between windows and linux, but doesn't allow  you to support power shell, command prompt or bash on windows.

```json
{
    "environment": {
        "prepend": {
            "PATH": [
                "{relative_root}/important_directory{;}{relative_root}/other_directory",
                "{PATH!e}",
            ]
        }
    }
}
```

This adds support for `!e` string format conversion. `{PATH!e}` will be changed to `$PATH` in bash, `$env:PATH` in power shell, and `%PATH%` in command prompt. This works for any set environment variable name. This respects bash on windows using `;` as its pathsep and `:` on linux.

It also adds support for `{;}` that will be replaced with `;` or `:`. This feature was developed before you could pass lists to environment variables, but allows for a little more flexibility in defining multiple path env variables.

