### PR TITLE
Fix issue using hab launch with complex aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,23 @@ same configuration syntax you would use in a pip requirements file.
 
 The resolved versions matching the requested distros are shown in the `versions` property.
 
+# Debugging
+
+## Debugging generated scripts
+
+Hab doesn't use a console_script entry point to create an exe for its cli. It uses a shell
+specific [launch script](bin). This script runs hab as a python process to create
+temporary shell scripts to configure the shell(launching a new one if required).
+This prevents the need to keep the python process running and prevents shell
+corruption if that python process is killed. The shell scripts are written to the
+temp location for the shell/os. On windows this should be written to `%tmp%` and
+`$TMPDIR` on linux.
+
+Hab does its best to remove these temp script files on exit so inspecting them can be
+difficult. The best way to view them is to run a `hab env` or `hab launch` command
+this will leave the hab process running while you find and view the config and launch
+scripts in the temp directory. Once you are finished exit the hab process and they
+will be removed.
 
 # Caveats
 

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -475,7 +475,7 @@ class HabBase(with_metaclass(HabMeta, anytree.NodeMixin)):
             ret["prompt"] = 'set "PROMPT=[{uri}] $P$G"\n'
             ret["launch"] = 'cmd.exe /k "{path}"\n'
             # You can't directly call a doskey alias in a batch script
-            ret["run_alias"] = '"{value}"{args}\n'
+            ret["run_alias"] = '{value}{args}\n'
         elif ext == ".ps1":
             ret["alias_setter"] = "function {key}() {{ {value} $args }}\n"
             ret["comment"] = "# "
@@ -592,7 +592,9 @@ class HabBase(with_metaclass(HabMeta, anytree.NodeMixin)):
                     args = ''
 
                 launch_info = dict(
-                    key=launch, value=self.aliases.get(launch, ""), args=args
+                    key=launch,
+                    value=self.shell_escape(ext, self.aliases.get(launch, "")),
+                    args=args,
                 )
                 fle.write("\n")
                 fle.write("{}Run the requested command\n".format(shell["comment"]))


### PR DESCRIPTION
Escape and turn list alias commands into compatible strings.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

In command prompt using `hab launch ... alias ...` for complex aliases(list of commands) doesn't work and `"The filename, directory name, or volume label syntax is incorrect."` is printed.

Fix this and add missing tests for launch feature for command prompt, power shell and bash.