### PR TITLE
Add better error reporting if setuptools-scm is not installed

### DIFF
--- a/hab/errors.py
+++ b/hab/errors.py
@@ -20,3 +20,31 @@ class _IgnoredVersionError(RequirementError):
 
 class MaxRedirectError(RequirementError):
     """The maximum number of redirects was reached without resolving successfully."""
+
+
+class InvalidVersionError(LookupError):
+    """Provides info on resolving why it was unable to generate a valid version number"""
+
+    default_message = (
+        'Hab was unable to determine the version for "{filename}".\n'
+        "  The version is defined in one of several ways checked in this order:\n"
+        "  1. The version property in `.hab.json`.\n"
+        "  2. A `.hab_version.txt` file next to `.hab.json`.\n"
+        "  3. `.hab.json`'s parent directory name.\n"
+        "  4. setuptools_scm can get a version from version control.\n"
+        "  The preferred method is #3 for deployed releases. #4 is the "
+        "preferred method for developer working copies."
+    )
+
+    def __init__(self, filename, error=None, message=None):
+        self.filename = filename
+        self.error = error
+        if message is None:
+            message = self.default_message
+        self.message = message
+
+    def __str__(self):
+        ret = self.message.format(filename=self.filename)
+        if self.error:
+            ret = f'{self.error}\n{ret}'
+        return ret

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ write_to = "hab/version.py"
 
 [tool.black]
 skip-string-normalization = true
+
+[tool.isort]
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     colorama
     future>=0.18.2
     packaging>=20.0
+    setuptools-scm[toml]>=4
 python_requires = >=3.6
 include_package_data = True
 scripts =

--- a/tests/distros_version/release/.hab.json
+++ b/tests/distros_version/release/.hab.json
@@ -1,0 +1,14 @@
+{
+    "name": "the_dcc",
+    "environment": {},
+    "distros": [
+        "the_dcc_plugin_a>=1.0",
+        "the_dcc_plugin_b>=0.9",
+        "the_dcc_plugin_e"
+    ],
+    "aliases": {
+        "windows": [
+            ["dcc", "{relative_root}\\the_dcc.exe"]
+        ]
+    }
+}


### PR DESCRIPTION
Restore hard requirement of setuptools-scm, hab was designed to require it.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

Re-adds setuptools_scm as a hard pip requirement. Adds better error reporting if setuptools_scm is not installed, and improves test coverage over distro_version.py.