### PR TITLE
Add freeze support

### DIFF
--- a/.github/workflows/python-static-analysis-and-test.yml
+++ b/.github/workflows/python-static-analysis-and-test.yml
@@ -64,9 +64,17 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install tox
 
+      - name: Run begin
+        run: |
+          tox -e begin
+
       - name: Run Tox
         run: |
           tox -e py
+
+      - name: Run end
+        run: |
+          tox -e end
 
 
   test-json5:
@@ -97,6 +105,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install tox
 
+      - name: Run begin
+        run: |
+          tox -e begin
+
       - name: Run Tox
         run: |
           tox -e py-json5
+
+      - name: Run end
+        run: |
+          tox -e end

--- a/README.md
+++ b/README.md
@@ -329,7 +329,9 @@ of environment variable keys and the values to store.
 The `HabBase.environment` property shows the final resolved
 environment variables that will be applied. When using a resolved `FlatConfig` object,
 environment also contains the merger of all environment_config definitions for all
-`distros`.
+`distros`. When building append and prepend environment variables it processes
+each dependency in a depth-first manner.
+
 These environment variables will be directly set if there is a value, and unset if the
 value is blank. Hab doesn't inherit the session/system/user environment variable
 values with the exception of the `PATH` variable as this would break the system.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,41 @@ $ hab env projectDummy/Thug
 The cli prompt is updated while inside a hab config is active. It is `[URI] [cwd]`
 Where URI is the uri requested and cwd is the current working directory.
 
+## Restoring resolved configuration
+
+Under normal operation hab resolves the configuration it loads each time it is run.
+This makes it easy to get updates to the configuration by re-launching hab. However,
+if you want to load the same hab configuration at a later date or on another computer
+it's possible a new distro version has been released or some config settings have
+been modified. For example if you submit a render job to the farm, you want every
+frame to render using the same hab configuration not what ever it happens to
+resolve for that launch.
+
+To handle this the hab cli stores the current configuration in the `HAB_FREEZE`
+environment variable. This is stored as a base64 encoded json string so it can
+be easily recovered. See `hab.utils.decode_freeze` to decode it.
+
+You can even use a frozen config on other platforms as long as you properly
+configure `platform_path_maps` in your site config.
+
+Using the cli to save a freeze to disk as json using dump using `--format json`.
+```bash
+hab dump projectDummy --format freeze > /tmp/frozen_config.json
+```
+
+Restoring a frozen config from a json file using the cli. This works for commands
+other than `dump`.
+```bash
+hab dump --unfreeze /tmp/frozen_config.json
+```
+
+Similarly you can save/load the encoded freeze string using `--format freeze`.
+
+```bash
+export frozen_config=$(hab dump app/nuke13 -f freeze)
+hab dump --unfreeze $frozen_config
+```
+
 ## API
 
 TODO

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ If the provided uri has no configurations provided, the default configuration is
 This also supports inheritance with some special rules, see
 [config inheritance](#config-inheritance) for more details.
 
+The provided URI is always stored in the `HAB_URI` environment variable.
+
 ## CLI
 
 Hab is designed as an api with cli support. The majority of the actual work is

--- a/README.md
+++ b/README.md
@@ -235,9 +235,10 @@ passed but Thug does not have a config, its parent project_a is used. If there i
 config for project_a, the default config will be used.
 
 The config system has an inheritance system that follows a tree structure. If a property
-is `NotSet` on the chosen config and the config has inherit enabled the closest parent
-with that property set will be used. If the root of the tree has inherit enabled, and
-the property still is `NotSet`, then the `default` tree will be checked.
+is `hab.NotSet` on the chosen config and the config has inherit enabled the closest
+parent with that property set will be used. If the root of the tree has inherit
+enabled, and the property still is `hab.NotSet`, then the `default` tree will be
+checked.
 
 When the default tree is checked when resolving inheritance, some special rules for
 matching contexts are applied. It will attempt to find the most specific context defined

--- a/bin/hab
+++ b/bin/hab
@@ -5,15 +5,13 @@
 # supports. This calls the python module cli passing the arguments to it and
 # ends up calling the script file that code generates if required.
 
-# Generate unique temp file names
-temp_launch_file=$(mktemp --suffix _hab_launch.sh)
-temp_config_file=$(mktemp --suffix _hab_config.sh)
-
-# Remove the files that were created, we don't want them at this point.
-rm -f $temp_launch_file $temp_config_file
+# Generate a unique temp directory to contain all of our script files
+temp_directory=$(mktemp -d 2>/dev/null || mktemp -d -t 'hab')
+temp_launch_file=$temp_directory/hab_launch.sh
+temp_config_file=$temp_directory/hab_config.sh
 
 # Ensure the tempfiles are remove on exit if they were created
-trap "rm -f $temp_launch_file $temp_config_file" EXIT
+trap "rm -rf $temp_directory" EXIT
 
 # Calculate the command to run python with
 if [[ ! -z "${HAB_PYTHON}" ]]; then
@@ -35,7 +33,7 @@ else
 fi
 
 # Call our worker python process that may write the temp filename
-$py_exe -m hab --file-config $temp_config_file --file-launch $temp_launch_file "$@"
+$py_exe -m hab --script-dir $temp_directory --script-ext ".sh" "$@"
 
 # Run the launch or config script if it was created on disk
 if test -f "$temp_launch_file"; then

--- a/bin/hab.bat
+++ b/bin/hab.bat
@@ -7,12 +7,13 @@
 
 :: Generate a unique temp file name
 :uniqLoop
-set "temp_config_file=%tmp%\hab~%RANDOM%"
-if exist "%temp_config_file%_config.bat" goto :uniqLoop
+set "temp_directory=%tmp%\hab~%RANDOM%"
+if exist "%temp_directory%" goto :uniqLoop
 
 :: Create the launch and config filenames we will end up using
-set "temp_launch_file=%temp_config_file%_launch.bat"
-set "temp_config_file=%temp_config_file%_config.bat"
+mkdir %temp_directory%
+set "temp_launch_file=%temp_directory%\hab_launch.bat"
+set "temp_config_file=%temp_directory%\hab_config.bat"
 
 :: Calculate the command to run python with
 SETLOCAL ENABLEEXTENSIONS
@@ -28,7 +29,7 @@ IF DEFINED HAB_PYTHON (
 )
 
 :: Call our worker python process that may write the temp filename
-%py_exe% -m hab --file-config "%temp_config_file%" --file-launch "%temp_launch_file%" %*
+%py_exe% -m hab --script-dir "%temp_directory%" --script-ext ".bat" %*
 ENDLOCAL
 
 :: Run the launch or config script if it was created on disk
@@ -43,12 +44,7 @@ if exist %temp_launch_file% (
 :: the config scripts turn echo back on, turn it off again
 @ECHO OFF
 
-:: Remove the temp files if they exist
-if exist %temp_launch_file% (
-    del "%temp_launch_file%"
-)
-if exist %temp_config_file% (
-    del "%temp_config_file%"
-)
+:: Remove the temp directory and its contents
+RMDIR /S /Q %temp_directory%
 
 @ECHO ON

--- a/hab/__init__.py
+++ b/hab/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import print_function
 
 __all__ = [
-    'Resolver',
     '__version__',
     'Config',
-    'HabBase',
     'DistroVersion',
+    'HabBase',
+    'NotSet',
+    'Resolver',
     'Site',
     'Solver',
 ]
@@ -16,7 +17,12 @@ import logging
 import anytree
 from packaging.requirements import Requirement
 
+# isort: on # Note: Future imports depend on NotSet so it must be imported here
 from . import utils
+from .utils import NotSet
+
+# isort: off
+
 from .errors import _IgnoredVersionError
 from .parsers import Config, DistroVersion, HabBase
 from .site import Site

--- a/hab/cli.py
+++ b/hab/cli.py
@@ -1,15 +1,50 @@
 import logging
+import re
 from pathlib import Path
 
 import click
 
-from . import Resolver, Site
+from . import Resolver, Site, __version__
+from .parsers.unfrozen_config import UnfrozenConfig
+from .utils import decode_freeze, dumps_json, encode_freeze, json
 
 logger = logging.getLogger(__name__)
 
 
 # No one wants to actually type `--help`
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+
+class UnfrozenType(click.Path):
+    """Accepts a hab frozen string, or a file path to a document containing a
+    frozen hab configuration. Returns the decoded python dictionary.
+    """
+
+    name = "unfrozen"
+
+    def __init__(
+        self, exists=True, path_type=Path, file_okay=True, resolve_path=True, **kwargs
+    ):
+        super(UnfrozenType, self).__init__(
+            exists=exists,
+            path_type=path_type,
+            file_okay=file_okay,
+            resolve_path=resolve_path,
+            **kwargs,
+        )
+
+    def convert(self, value, param, ctx):
+        if re.match(r'^v\d+:', value):
+            return decode_freeze(value)
+
+        # If its not a string, convert to a Path object matching requirements
+        try:
+            data = super(UnfrozenType, self).convert(value, param, ctx)
+        except ValueError:
+            self.fail(
+                f"{value!r} is not a valid frozen version or file path.", param, ctx
+            )
+        return json.load(data.open())
 
 
 class SharedSettings(object):
@@ -41,7 +76,13 @@ class SharedSettings(object):
         return self._resolver
 
     def write_script(
-        self, uri, launch=None, exit=False, args=None, create_launch=False
+        self,
+        uri,
+        unfreeze=None,
+        launch=None,
+        exit=False,
+        args=None,
+        create_launch=False,
     ):
         """Generate the script the calling shell scripts expect to setup the environment"""
         logger.info(f"Context: {uri}")
@@ -51,7 +92,18 @@ class SharedSettings(object):
             # convert to list, subprocess.list2cmdline does not like tuples
             args = list(args)
 
-        ret = self.resolver.resolve(uri)
+        if unfreeze:
+            # Load frozen json data instead of processing the URI
+            ret = UnfrozenConfig(unfreeze, self.resolver)
+        elif uri is None:
+            # If the user didn't choose a different report type, or use the
+            # unfreeze option, raise the exception click would raise if
+            # uri didn't have `required=False`.
+            raise click.UsageError("Missing argument 'URI'.")
+        else:
+            # Otherwise just process the uri like normal
+            ret = self.resolver.resolve(uri)
+
         ret.write_script(
             self.script_dir,
             self.script_ext,
@@ -63,6 +115,7 @@ class SharedSettings(object):
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
+@click.version_option(__version__, prog_name="hab")
 @click.option(
     "--site",
     "site_paths",
@@ -114,7 +167,13 @@ def cli(ctx, site_paths, verbosity, script_dir, script_ext, pre, requirement):
 
 
 @cli.command()
-@click.argument("uri")
+@click.argument("uri", required=False)
+@click.option(
+    "-u",
+    "--unfreeze",
+    type=UnfrozenType(),
+    help="Path to frozen json file to load instead of specifying a URI.",
+)
 @click.option(
     "-l",
     "--launch",
@@ -122,13 +181,16 @@ def cli(ctx, site_paths, verbosity, script_dir, script_ext, pre, requirement):
     help="Run this alias after activating. This leaves the new shell active.",
 )
 @click.pass_obj
-def env(settings, uri, launch):
+def env(settings, uri, unfreeze, launch):
     """Configures and launches a new shell with the resolved setup."""
-    settings.write_script(uri, create_launch=True, launch=launch)
+
+    settings.write_script(uri, unfreeze=unfreeze, create_launch=True, launch=launch)
 
 
 @cli.command()
-@click.argument("uri")
+# If the report_type and unfreeze options are used, uri is not required. This
+# is manually checked in the code below where it raises `click.UsageError`.
+@click.argument("uri", required=False)
 @click.pass_obj
 @click.option(
     "--env/--no-env",
@@ -161,7 +223,23 @@ def env(settings, uri, launch):
     count=True,
     help="Show increasingly detailed output. Can be used up to 3 times.",
 )
-def dump(settings, uri, env, env_config, report_type, flat, verbosity):
+@click.option(
+    "-u",
+    "--unfreeze",
+    type=UnfrozenType(),
+    help="Path to frozen json file to load instead of specifying a URI.",
+)
+@click.option(
+    "-f",
+    "--format",
+    "format_type",
+    type=click.Choice(["nice", "freeze", "json", "versions"]),
+    default="nice",
+    help="Choose how the output is formatted.",
+)
+def dump(
+    settings, uri, env, env_config, report_type, flat, verbosity, unfreeze, format_type
+):
     """Resolves and prints the requested setup."""
     logger.info("Context: {}".format(uri))
     if report_type in ("forest", "f"):
@@ -170,22 +248,42 @@ def dump(settings, uri, env, env_config, report_type, flat, verbosity):
         click.echo(" Distros ".center(50, "-"))
         click.echo(settings.resolver.dump_forest(settings.resolver.distros))
     elif report_type in ("site", "s"):
-        click.echo(settings.resolver.site.dump())
+        click.echo(settings.resolver.site.dump(verbosity=verbosity))
     else:
-        if flat:
+        if unfreeze:
+            ret = UnfrozenConfig(unfreeze, settings.resolver)
+        elif uri is None:
+            # If the user didn't choose a different report type, or use the
+            # unfreeze option, raise the exception click would raise if
+            # uri didn't have `required=False`.
+            raise click.UsageError("Missing argument 'URI'.")
+        elif flat:
             ret = settings.resolver.resolve(uri)
         else:
             ret = settings.resolver.closest_config(uri)
 
-        click.echo(
-            ret.dump(
+        if format_type == "freeze":
+            ret = encode_freeze(ret.freeze())
+        elif format_type == "json":
+            ret = dumps_json(ret.freeze(), indent=2)
+        elif format_type == "versions":
+            ret = '\n'.join([v.name for v in ret.versions])
+        else:
+            ret = ret.dump(
                 environment=env, environment_config=env_config, verbosity=verbosity
             )
-        )
+
+        click.echo(ret)
 
 
 @cli.command()
-@click.argument("uri")
+@click.argument("uri", required=False)
+@click.option(
+    "-u",
+    "--unfreeze",
+    type=UnfrozenType(),
+    help="Path to frozen json file to load instead of specifying a URI.",
+)
 @click.option(
     "-l",
     "--launch",
@@ -193,12 +291,12 @@ def dump(settings, uri, env, env_config, report_type, flat, verbosity):
     help="Run this alias after activating. This leaves the new shell activated.",
 )
 @click.pass_obj
-def activate(settings, uri, launch):
+def activate(settings, uri, unfreeze, launch):
     """Resolves the setup and updates in the current shell.
 
     In powershell and bash you must use the source dot: ". hab activate ..."
     """
-    settings.write_script(uri, launch=launch)
+    settings.write_script(uri, unfreeze=unfreeze, launch=launch)
 
 
 @cli.command(
@@ -206,12 +304,18 @@ def activate(settings, uri, launch):
         ignore_unknown_options=True,
     )
 )
-@click.argument("uri")
-@click.argument("alias")
+@click.argument("uri", required=False)
+@click.option(
+    "-u",
+    "--unfreeze",
+    type=UnfrozenType(),
+    help="Path to frozen json file to load instead of specifying a URI.",
+)
+@click.argument("alias", required=False)
 # Pass all remaining arguments to the requested alias
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
 @click.pass_obj
-def launch(settings, uri, alias, args):
+def launch(settings, uri, unfreeze, alias, args):
     """Configure and launch an alias without modifying the current shell.
     The first argument is a URI, The second argument is the ALIAS to launch. Any
     additional arguments are passed as launch arguments to the alias. Note, if using
@@ -219,7 +323,27 @@ def launch(settings, uri, alias, args):
     used may not make it to the alias launch arguments.
     (ie: '/c/Program\\ Files').
     """
-    settings.write_script(uri, create_launch=True, launch=alias, exit=True, args=args)
+    # To support making URI not required if unfreeze is specified, we have to
+    # do all of the validation click would normally do ourselves.
+    if unfreeze:
+        # If using --unfreeze, uri contains the alias, and alias contains
+        # the first argument if provided, and args contains any remaining
+        # arguments. Rebuild them so they are the correct values.
+        if alias is not None:
+            args = (alias,) + args
+        alias = uri
+        uri = None
+    elif not uri:
+        # Provide user feedback if a neither uri or unfreeze are provided
+        raise click.UsageError("Missing argument 'URI'.")
+
+    if not alias:
+        # If alias was not provided, replicate the error click normally raises
+        raise click.UsageError("Missing argument 'ALIAS'.")
+
+    settings.write_script(
+        uri, unfreeze=unfreeze, create_launch=True, launch=alias, exit=True, args=args
+    )
 
 
 if __name__ == "__main__":

--- a/hab/merge_dict.py
+++ b/hab/merge_dict.py
@@ -4,15 +4,47 @@ from . import utils
 
 
 class MergeDict(object):
-    def __init__(self, platform=None, **format_kwargs):
+    def __init__(self, platform=None, platforms=("linux", "windows"), **format_kwargs):
         self.format_kwargs = format_kwargs
         self.formatter = self.default_format
         self.pathsep = os.pathsep
+        self.platforms = platforms
         self.validator = None
 
         if platform is None:
             platform = utils.platform()
         self.platform = platform
+
+    def apply_platform_wildcards(self, data, output=None):
+        """Ensure the data dict is platform specific and any wildcard entries
+        are applied to all of self.platforms.
+
+        Args:
+            data (dict): A dictionary of settings to apply. `make_os_specific`
+                is called on it.
+            output (dict, optional): If provided, the dictionary is updated in
+                with the info stored in data. If not, a new dictionary is
+                created and returned.
+
+        Returns:
+            dict: The modified dictionary. If output was provided it is the
+                same object, if not a new dict is returned.
+        """
+        data = self.make_os_specific(data)
+
+        if output is None:
+            output = {"os_specific": True}
+
+        for platform in self.platforms:
+            platform_data = output.setdefault(platform, {})
+
+            if "*" in data:
+                self.update_platform(platform_data, data["*"])
+
+            if platform in data:
+                self.update_platform(platform_data, data[platform])
+
+        return output
 
     def default_format(self, value):
         if isinstance(value, list):
@@ -52,36 +84,52 @@ class MergeDict(object):
 
         return a + b
 
-    def update(self, base, changes):
-        """Check and update environment with the provided environment config."""
+    @classmethod
+    def make_os_specific(cls, data):
+        """Ensure the dict conforms to the "os_specific=True" specification.
+        If os_specific is missing or not true, a new dict is returned with a
+        copy of data stored under the "*" key with `os_specific` removed.
 
-        # If os_specific is specified, we are defining environment variables per-os
-        # not globally. Lookup the current os's configuration.
-        if changes.get("os_specific", False):
-            changes = changes.get(self.platform, {})
+        Args:
+            data (dict): The dict to make os_specific. The original dict is
+                returned if it's already os_specific, otherwise a new dict is
+                returned.
 
+        Returns:
+            dict: A dict that conforms to the "os_specific=True" format.
+        """
+        if not data.get("os_specific", False):
+            # Remove os_specific if it was defined so we don't keep it on the
+            # wildcard platform dict.
+            data = data.copy()
+            data.pop("os_specific", False)
+            data = {'*': data}
+            data["os_specific"] = True
+        return data
+
+    def update_platform(self, data, changes):
         if self.validator:
             self.validator(changes)
 
         if "unset" in changes:
             # When applying the env vars later None will trigger removing the env var.
             # The other operations may end up replacing this value.
-            base.update({key: None for key in changes["unset"]})
+            data.update({key: None for key in changes["unset"]})
 
         # set, prepend, append are all treated as set operations, this lets us override
         # base user and system variable values without them causing issues.
         if "set" in changes:
             for key, value in changes["set"].items():
-                base[key] = self.formatter(value)
-                if isinstance(base[key], str):
-                    base[key] = [base[key]]
+                data[key] = self.formatter(value)
+                if isinstance(data[key], str):
+                    data[key] = [data[key]]
 
         for operation in ("prepend", "append"):
             if operation not in changes:
                 continue
 
             for key, value in changes[operation].items():
-                existing = base.get(key, "")
+                existing = data.get(key, "")
                 if existing:
                     if operation == "prepend":
                         value = self.join(value, existing)
@@ -90,4 +138,4 @@ class MergeDict(object):
                 else:
                     # Convert value into a list if it isn't one
                     value = self.join(value, [])
-                base[key] = self.formatter(value)
+                data[key] = self.formatter(value)

--- a/hab/parsers/__init__.py
+++ b/hab/parsers/__init__.py
@@ -5,7 +5,7 @@ from .distro import Distro
 from .distro_version import DistroVersion
 from .flat_config import FlatConfig
 from .hab_base import HabBase
-from .meta import HabMeta, NotSet, hab_property
+from .meta import HabMeta, hab_property
 from .placeholder import Placeholder
 
 __all__ = [
@@ -16,6 +16,5 @@ __all__ = [
     'hab_property',
     'HabBase',
     'HabMeta',
-    'NotSet',
     'Placeholder',
 ]

--- a/hab/parsers/__init__.py
+++ b/hab/parsers/__init__.py
@@ -7,6 +7,7 @@ from .flat_config import FlatConfig
 from .hab_base import HabBase
 from .meta import HabMeta, hab_property
 from .placeholder import Placeholder
+from .unfrozen_config import UnfrozenConfig
 
 __all__ = [
     'Config',
@@ -17,4 +18,5 @@ __all__ = [
     'HabBase',
     'HabMeta',
     'Placeholder',
+    'UnfrozenConfig',
 ]

--- a/hab/parsers/config.py
+++ b/hab/parsers/config.py
@@ -7,17 +7,13 @@ class Config(HabBase):
     variables need to be loaded if this config is chosen. This does not resolve `NotSet`
     values, see `FlatConfig` for the final resolved values that are actually applied."""
 
-    def _init_variables(self):
-        super(Config, self)._init_variables()
-        self.inherits = NotSet
-
     @hab_property(verbosity=2)
     def inherits(self):
-        return self._inherits
+        return self.frozen_data.get("inherits", NotSet)
 
     @inherits.setter
     def inherits(self, inherits):
-        self._inherits = inherits
+        self.frozen_data["inherits"] = inherits
 
     def load(self, filename):
         data = super(Config, self).load(filename)

--- a/hab/parsers/config.py
+++ b/hab/parsers/config.py
@@ -1,5 +1,6 @@
+from .. import NotSet
 from .hab_base import HabBase
-from .meta import NotSet, hab_property
+from .meta import hab_property
 
 
 class Config(HabBase):

--- a/hab/parsers/distro_version.py
+++ b/hab/parsers/distro_version.py
@@ -13,19 +13,15 @@ class DistroVersion(HabBase):
     _context_method = "name"
     _placeholder = Distro
 
-    def _init_variables(self):
-        super(DistroVersion, self)._init_variables()
-        self.aliases = NotSet
-
     @hab_property()
     def aliases(self):
         """List of the names and commands that need created to launch desired
         applications."""
-        return self._aliases
+        return self.frozen_data.get("aliases", NotSet)
 
     @aliases.setter
     def aliases(self, aliases):
-        self._aliases = aliases
+        self.frozen_data["aliases"] = aliases
 
     def load(self, filename):
         # Fill in the DistroVersion specific settings before calling super
@@ -84,4 +80,4 @@ class DistroVersion(HabBase):
         # NOTE: super doesn't work for a @property.setter
         if version and not isinstance(version, Version):
             version = Version(version)
-        self._version = version
+        self.frozen_data["version"] = version

--- a/hab/parsers/distro_version.py
+++ b/hab/parsers/distro_version.py
@@ -1,9 +1,10 @@
 from packaging.version import InvalidVersion, Version
 
+from .. import NotSet
 from ..errors import InvalidVersionError, _IgnoredVersionError
 from .distro import Distro
 from .hab_base import HabBase
-from .meta import NotSet, hab_property
+from .meta import hab_property
 
 
 class DistroVersion(HabBase):

--- a/hab/parsers/flat_config.py
+++ b/hab/parsers/flat_config.py
@@ -80,6 +80,9 @@ class FlatConfig(Config):
         if empty:
             for version in self.versions:
                 self.update_environment(version.environment_config, obj=version)
+            # Add the HAB_URI env var so scripts know they are in an activated hab
+            # environment and the original uri the user requested.
+            self._environment['HAB_URI'] = [self.uri]
 
         return self._environment
 

--- a/hab/parsers/flat_config.py
+++ b/hab/parsers/flat_config.py
@@ -1,7 +1,8 @@
 import logging
 
+from .. import NotSet
 from .config import Config
-from .meta import NotSet, hab_property
+from .meta import hab_property
 
 logger = logging.getLogger(__name__)
 

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -545,11 +545,11 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
         self.frozen_data["version"] = version
 
     def write_script(
-        self, config_script, launch_script=None, launch=None, exit=False, args=None
+        self, script_dir, ext, launch=None, exit=False, args=None, create_launch=False
     ):
         """Write the configuration to a script file to be run by terminal."""
-        config_script = Path(config_script)
-        ext = config_script.suffix
+        script_dir = Path(script_dir)
+        config_script = script_dir / f'hab_config{ext}'
         shell = self.shell_formats(ext)
 
         with config_script.open("w") as fle:
@@ -609,13 +609,14 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
 
             # When using `hab launch`, we need to exit the shell that launch_script is
             # going to create when the alias exits.
-            if exit and launch_script:
+            if exit and create_launch:
                 fle.write("\n")
                 fle.write("{}\n".format(shell.get("exit", "exit")))
 
             if shell["postfix"]:
                 fle.write(shell["postfix"])
 
-        if launch_script:
-            with Path(launch_script).open("w") as fle:
+        if create_launch:
+            launch_script = script_dir / f'hab_launch{ext}'
+            with launch_script.open("w") as fle:
                 fle.write(shell["launch"].format(path=config_script))

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -7,20 +7,19 @@ from pathlib import Path
 
 import anytree
 import colorama
-from future.utils import with_metaclass
 from packaging.version import Version
 
-from .. import utils
+from .. import NotSet, utils
 from ..errors import DuplicateJsonError
 from ..formatter import Formatter
 from ..site import MergeDict
 from ..solvers import Solver
-from .meta import HabMeta, NotSet, hab_property
+from .meta import HabMeta, hab_property
 
 logger = logging.getLogger(__name__)
 
 
-class HabBase(with_metaclass(HabMeta, anytree.NodeMixin)):
+class HabBase(anytree.NodeMixin, metaclass=HabMeta):
     """Base class for the various parser classes. Provides most of the functionality
     to parse a json configuration file and resolve it for use in hab.
 

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -528,7 +528,10 @@ class HabBase(with_metaclass(HabMeta, anytree.NodeMixin)):
         merger = MergeDict(relative_root=self.dirname, platform=self._platform)
         merger.formatter = obj.format_environment_value
         merger.validator = self.check_environment
-        merger.update(self._environment, environment_config)
+        # Flatten the site configuration down to per-platform configurations
+        output = merger.apply_platform_wildcards(environment_config)
+        # Apply the site settings to this object for the current platform
+        self._environment.update(output.get(merger.platform))
 
     @property
     def uri(self):

--- a/hab/parsers/meta.py
+++ b/hab/parsers/meta.py
@@ -1,18 +1,3 @@
-class NotSet(object):
-    """The data for this property is not currently set."""
-
-    def __bool__(self):
-        """NotSet should be treated as False when booled Python 3"""
-        return False
-
-    def __str__(self):
-        return "NotSet"
-
-
-# Make this a singleton so it works like a boolean False for if statements.
-NotSet = NotSet()
-
-
 class _HabProperty(property):
     """The @property decorator that can be type checked by the `HabMeta` metaclass
 

--- a/hab/parsers/unfrozen_config.py
+++ b/hab/parsers/unfrozen_config.py
@@ -1,0 +1,38 @@
+import logging
+from copy import deepcopy
+
+from .. import NotSet
+from .config import Config
+from .meta import hab_property
+
+logger = logging.getLogger(__name__)
+
+
+class UnfrozenConfig(Config):
+    def __init__(self, frozen_data, resolver, uri=NotSet, forest=None):
+        super(UnfrozenConfig, self).__init__(None, resolver)
+        self.frozen_data = deepcopy(frozen_data)
+
+    @classmethod
+    def _dump_versions(cls, value, verbosity=0, color=None):
+        """Returns the version information for this object as a list of strings."""
+        # Frozen versions are already a list of strings
+        return sorted(value)
+
+    @hab_property()
+    def aliases(self):
+        """List of the names and commands that need created to launch desired
+        applications."""
+        return self.frozen_data.get("aliases", {}).get(self._platform, [])
+
+    @property
+    def fullpath(self):
+        return self.frozen_data["uri"]
+
+    @property
+    def uri(self):
+        return self.frozen_data["uri"]
+
+    @hab_property(verbosity=1)
+    def versions(self):
+        return self.frozen_data["versions"]

--- a/hab/site.py
+++ b/hab/site.py
@@ -24,6 +24,7 @@ class Site(UserDict):
             "config_paths": [],
             "distro_paths": [],
             "ignored_distros": ["release", "pre"],
+            "platforms": ["windows", "mac", "linux"],
         }
     }
 

--- a/hab/site.py
+++ b/hab/site.py
@@ -87,7 +87,7 @@ class Site(UserDict):
         """Iterates over each file in self.path. Replacing the value of each key.
         The last file in the list will have its settings applied even if other
         files define them."""
-        for path in self.paths:
+        for path in reversed(self.paths):
             self.load_file(path)
 
         # Ensure any platform_path_maps are converted to pathlib objects.

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -175,5 +175,9 @@ def path_forward_slash(path):
 
 
 def platform():
-    """Returns the current operating system as `windows` or `linux`."""
-    return "windows" if sys.platform == "win32" else "linux"
+    """Returns the current operating system as `windows`, `mac` or `linux`."""
+    if sys.platform == "darwin":
+        return "mac"
+    if sys.platform == "win32":
+        return "windows"
+    return "linux"

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -122,7 +122,7 @@ def dump_object(obj, label="", width=80, flat_list=False, color=False):
     elif isinstance(obj, (dict, UserDict)):
         rows = []
         lbl = label
-        for k, v in obj.items():
+        for k, v in sorted(obj.items()):
             rows.append(
                 dump_object(
                     v,

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -169,6 +169,31 @@ def load_json_file(filename):
     return data
 
 
+class NotSet(object):
+    """The data for this property is not currently set."""
+
+    def __bool__(self):
+        """NotSet should be treated as False when booled Python 3"""
+        return False
+
+    def __str__(self):
+        return "NotSet"
+
+    def __copy__(self):
+        """Does not return a copy of this object, NotSet is intended to be a
+        singleton so it does not copy itself."""
+        return self
+
+    def __deepcopy__(self, memo):
+        """Does not return a copy of this object, NotSet is intended to be a
+        singleton so it does not copy itself."""
+        return self
+
+
+# Make this a singleton so it works like a boolean False for if statements.
+NotSet = NotSet()
+
+
 def path_forward_slash(path):
     """Converts a Path object into a string with forward slashes"""
     return str(path).replace('\\', '/')

--- a/tests/configs/not_set/env_path_hab_uri.json
+++ b/tests/configs/not_set/env_path_hab_uri.json
@@ -1,0 +1,10 @@
+{
+    "name": "env_path_hab_uri",
+    "context": ["not_set"],
+    "environment": {
+        "set": {
+            "HAB_URI": "invalid value"
+        }
+    },
+    "inherits": true
+}

--- a/tests/configs/not_set/not_set_no_distros.json
+++ b/tests/configs/not_set/not_set_no_distros.json
@@ -1,0 +1,10 @@
+{
+    "name": "no_distros",
+    "context": ["not_set"],
+    "inherits": false,
+    "environment": {
+        "append": {
+            "Test": "Case"
+        }
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import os
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PurePath
 
 import pytest
 from packaging.requirements import Requirement
@@ -49,6 +49,15 @@ class Helpers(object):
         for chk in check:
             chk = Requirement(chk)
             assert Helpers.cmp_requirement(req[chk.name], chk)
+
+    @staticmethod
+    def check_path_list(paths, checks):
+        """Casts the objects in both lists to PurePath objects so they can be
+        reliably asserted and differences easily viewed in the pytest output.
+        """
+        paths = [PurePath(p) for p in paths]
+        checks = [PurePath(p) for p in checks]
+        assert paths == checks
 
     @staticmethod
     def cmp_requirement(a, b):

--- a/tests/distros/the_dcc/1.2/.hab.json
+++ b/tests/distros/the_dcc/1.2/.hab.json
@@ -7,6 +7,9 @@
         "the_dcc_plugin_e"
     ],
     "aliases": {
+        "linux": [
+            ["dcc", "{relative_root}//the_dcc"]
+        ],
         "windows": [
             ["dcc", "{relative_root}\\the_dcc.exe"]
         ]

--- a/tests/distros/the_dcc_plugin_a/1.1/.hab.json
+++ b/tests/distros/the_dcc_plugin_a/1.1/.hab.json
@@ -1,12 +1,13 @@
 {
     "name": "the_dcc_plugin_a",
     "distros": [
-        "the_dcc_plugin_d",
-        "the_dcc_plugin_e<2.0"
+        "the_dcc_plugin_e<2.0",
+        "the_dcc_plugin_d"
     ],
     "environment": {
         "append": {
-            "DCC_MODULE_PATH": "{relative_root}"
+            "DCC_MODULE_PATH": "{relative_root}",
+            "DCC_CONFIG_PATH": "{relative_root}"
         }
     }
 }

--- a/tests/distros/the_dcc_plugin_b/1.1/.hab.json
+++ b/tests/distros/the_dcc_plugin_b/1.1/.hab.json
@@ -3,6 +3,9 @@
     "environment": {
         "append": {
             "DCC_MODULE_PATH": "{relative_root}"
+        },
+        "prepend": {
+            "DCC_CONFIG_PATH": "{relative_root}"
         }
     }
 }

--- a/tests/distros/the_dcc_plugin_d/1.1/.hab.json
+++ b/tests/distros/the_dcc_plugin_d/1.1/.hab.json
@@ -3,6 +3,9 @@
     "environment": {
         "append": {
             "DCC_MODULE_PATH": "{relative_root}"
+        },
+        "prepend": {
+            "DCC_CONFIG_PATH": "{relative_root}"
         }
     }
 }

--- a/tests/distros/the_dcc_plugin_e/1.1/.hab.json
+++ b/tests/distros/the_dcc_plugin_e/1.1/.hab.json
@@ -2,7 +2,8 @@
     "name": "the_dcc_plugin_e",
     "environment": {
         "append": {
-            "DCC_MODULE_PATH": "{relative_root}"
+            "DCC_MODULE_PATH": "{relative_root}",
+            "DCC_CONFIG_PATH": "{relative_root}"
         }
     }
 }

--- a/tests/frozen.json
+++ b/tests/frozen.json
@@ -1,0 +1,65 @@
+{
+  "context": [
+    "not_set"
+  ],
+  "name": "distros",
+  "aliases": {
+    "windows": {
+      "dcc": "TEST_DIR_NAME\\the_dcc.exe"
+    },
+    "linux": {
+      "dcc": "TEST_DIR_NAME//the_dcc"
+    }
+  },
+  "versions": [
+    "the_dcc==1.2",
+    "the_dcc_plugin_a==1.1",
+    "the_dcc_plugin_e==1.1",
+    "the_dcc_plugin_d==1.1",
+    "the_dcc_plugin_b==1.1"
+  ],
+  "inherits": false,
+  "environment": {
+    "windows": {
+      "Test": [
+        "Case"
+      ],
+      "DCC_MODULE_PATH": [
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_a/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_e/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_d/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_b/1.1"
+      ],
+      "DCC_CONFIG_PATH": [
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_b/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_d/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_a/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_e/1.1"
+      ],
+      "HAB_URI": [
+        "not_set/distros"
+      ]
+    },
+    "linux": {
+      "Test": [
+        "Case"
+      ],
+      "DCC_MODULE_PATH": [
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_a/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_e/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_d/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_b/1.1"
+      ],
+      "DCC_CONFIG_PATH": [
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_b/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_d/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_a/1.1",
+        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_e/1.1"
+      ],
+      "HAB_URI": [
+        "not_set/distros"
+      ]
+    }
+  },
+  "uri": "not_set/distros"
+}

--- a/tests/frozen.json
+++ b/tests/frozen.json
@@ -25,16 +25,16 @@
         "Case"
       ],
       "DCC_MODULE_PATH": [
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_a/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_e/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_d/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_b/1.1"
+        "{config_root}/distros/the_dcc_plugin_a/1.1",
+        "{config_root}/distros/the_dcc_plugin_e/1.1",
+        "{config_root}/distros/the_dcc_plugin_d/1.1",
+        "{config_root}/distros/the_dcc_plugin_b/1.1"
       ],
       "DCC_CONFIG_PATH": [
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_b/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_d/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_a/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_e/1.1"
+        "{config_root}/distros/the_dcc_plugin_b/1.1",
+        "{config_root}/distros/the_dcc_plugin_d/1.1",
+        "{config_root}/distros/the_dcc_plugin_a/1.1",
+        "{config_root}/distros/the_dcc_plugin_e/1.1"
       ],
       "HAB_URI": [
         "not_set/distros"
@@ -45,16 +45,16 @@
         "Case"
       ],
       "DCC_MODULE_PATH": [
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_a/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_e/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_d/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_b/1.1"
+        "{config_root}/distros/the_dcc_plugin_a/1.1",
+        "{config_root}/distros/the_dcc_plugin_e/1.1",
+        "{config_root}/distros/the_dcc_plugin_d/1.1",
+        "{config_root}/distros/the_dcc_plugin_b/1.1"
       ],
       "DCC_CONFIG_PATH": [
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_b/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_d/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_a/1.1",
-        "C:/blur/dev/hab_/tests/distros/the_dcc_plugin_e/1.1"
+        "{config_root}/distros/the_dcc_plugin_b/1.1",
+        "{config_root}/distros/the_dcc_plugin_d/1.1",
+        "{config_root}/distros/the_dcc_plugin_a/1.1",
+        "{config_root}/distros/the_dcc_plugin_e/1.1"
       ],
       "HAB_URI": [
         "not_set/distros"

--- a/tests/frozen_no_distros.json
+++ b/tests/frozen_no_distros.json
@@ -1,0 +1,29 @@
+{
+    "raw": {
+        "context": [
+            "not_set"
+        ],
+        "name": "no_distros",
+        "inherits": false,
+        "environment": {
+            "windows": {
+                "Test": [
+                    "Case"
+                ],
+                "HAB_URI": [
+                    "not_set/no_distros"
+                ]
+            },
+            "linux": {
+                "Test": [
+                    "Case"
+                ],
+                "HAB_URI": [
+                    "not_set/no_distros"
+                ]
+            }
+        },
+        "uri": "not_set/no_distros"
+    },
+    "version1": "v1:eyJjb250ZXh0IjogWyJub3Rfc2V0Il0sICJuYW1lIjogIm5vX2Rpc3Ryb3MiLCAiaW5oZXJpdHMiOiBmYWxzZSwgImVudmlyb25tZW50IjogeyJ3aW5kb3dzIjogeyJUZXN0IjogWyJDYXNlIl0sICJIQUJfVVJJIjogWyJub3Rfc2V0L25vX2Rpc3Ryb3MiXX0sICJsaW51eCI6IHsiVGVzdCI6IFsiQ2FzZSJdLCAiSEFCX1VSSSI6IFsibm90X3NldC9ub19kaXN0cm9zIl19fSwgInVyaSI6ICJub3Rfc2V0L25vX2Rpc3Ryb3MifQ=="
+}

--- a/tests/merge_dict/merge_agnostic.json
+++ b/tests/merge_dict/merge_agnostic.json
@@ -1,0 +1,45 @@
+{
+    "file_one": {
+        "unset": [
+            "UNSET_VARIABLE"
+        ],
+        "prepend": {
+            "SHARED": "all_pre"
+        },
+        "append": {
+            "SHARED": "all"
+        }
+    },
+    "file_two": {
+        "unset": [
+            "UNSET_VARIABLE"
+        ],
+        "prepend": {
+            "SHARED": "all_pre_2"
+        },
+        "append": {
+            "SHARED": "all_2"
+        }
+    },
+    "out_data": {
+        "linux": {
+            "SHARED": [
+                "all_pre_2",
+                "all_pre",
+                "all",
+                "all_2"
+            ],
+            "UNSET_VARIABLE": null
+        },
+        "os_specific": true,
+        "windows": {
+            "SHARED": [
+                "all_pre_2",
+                "all_pre",
+                "all",
+                "all_2"
+            ],
+            "UNSET_VARIABLE": null
+        }
+    }
+}

--- a/tests/merge_dict/merge_specific.json
+++ b/tests/merge_dict/merge_specific.json
@@ -1,0 +1,131 @@
+{
+    "file_one": {
+        "os_specific": true,
+        "linux": {
+            "unset": [
+                "UNSET_VARIABLE_LIN"
+            ],
+            "set": {
+                "SET_BY_LINUX": "linux_value"
+            },
+            "append": {
+                "LIN_VARIABLE": "append_platform_lin",
+                "SHARED": "linux"
+            }
+        },
+        "windows": {
+            "unset": [
+                "UNSET_VARIABLE_WIN",
+                "UNSET_BY_WINDOWS"
+            ],
+            "append": {
+                "WIN_VARIABLE": "append_platform_win",
+                "SHARED": "windows"
+            }
+        },
+        "*": {
+            "unset": [
+                "UNSET_VARIABLE_ALL"
+            ],
+            "append": {
+                "ALL_VARIABLE": "append_platform_all",
+                "UNSET_BY_WINDOWS": "removed_by_windows",
+                "SET_BY_LINUX": "append_replaced_only_by_linux",
+                "SHARED": "all"
+            }
+        }
+    },
+    "file_two": {
+        "os_specific": true,
+        "linux": {
+            "unset": [
+                "UNSET_VARIABLE_LIN"
+            ],
+            "set": {
+                "SET_BY_LINUX": "linux_value_2"
+            },
+            "prepend": {
+                "LIN_VARIABLE": "prepend_platform_lin_2",
+                "SHARED": "prepend_linux_2"
+            },
+            "append": {
+                "LIN_VARIABLE": "append_platform_lin_2",
+                "SHARED": "linux_2"
+            }
+        },
+        "windows": {
+            "unset": [
+                "UNSET_VARIABLE_WIN",
+                "UNSET_BY_WINDOWS"
+            ],
+            "append": {
+                "WIN_VARIABLE": "append_platform_win_2",
+                "SHARED": "windows_2"
+            }
+        },
+        "*": {
+            "unset": [
+                "UNSET_VARIABLE_ALL"
+            ],
+            "append": {
+                "ALL_VARIABLE": "append_platform_all_2",
+                "UNSET_BY_WINDOWS": "removed_by_windows_2",
+                "SET_BY_LINUX": "append_replaced_only_by_linux_2",
+                "SHARED": "all_2"
+            }
+        }
+    },
+    "out_data": {
+        "linux": {
+            "ALL_VARIABLE": [
+                "append_platform_all",
+                "append_platform_all_2"
+            ],
+            "LIN_VARIABLE": [
+                "prepend_platform_lin_2",
+                "append_platform_lin",
+                "append_platform_lin_2"
+            ],
+            "SET_BY_LINUX": [
+                "linux_value_2"
+            ],
+            "SHARED": [
+                "prepend_linux_2",
+                "all",
+                "linux",
+                "all_2",
+                "linux_2"
+            ],
+            "UNSET_BY_WINDOWS": [
+                "removed_by_windows",
+                "removed_by_windows_2"
+            ],
+            "UNSET_VARIABLE_ALL": null,
+            "UNSET_VARIABLE_LIN": null
+        },
+        "os_specific": true,
+        "windows": {
+            "ALL_VARIABLE": [
+                "append_platform_all",
+                "append_platform_all_2"
+            ],
+            "SET_BY_LINUX": [
+                "append_replaced_only_by_linux",
+                "append_replaced_only_by_linux_2"
+            ],
+            "SHARED": [
+                "all",
+                "windows",
+                "all_2",
+                "windows_2"
+            ],
+            "UNSET_BY_WINDOWS": null,
+            "UNSET_VARIABLE_ALL": null,
+            "UNSET_VARIABLE_WIN": null,
+            "WIN_VARIABLE": [
+                "append_platform_win",
+                "append_platform_win_2"
+            ]
+        }
+    }
+}

--- a/tests/merge_dict/os_agnostic.json
+++ b/tests/merge_dict/os_agnostic.json
@@ -1,0 +1,25 @@
+{
+    "in_data": {
+        "unset": [
+            "UNSET_VARIABLE"
+        ],
+        "append": {
+            "SHARED": "all"
+        }
+    },
+    "out_data": {
+        "linux": {
+            "SHARED": [
+                "all"
+            ],
+            "UNSET_VARIABLE": null
+        },
+        "os_specific": true,
+        "windows": {
+            "SHARED": [
+                "all"
+            ],
+            "UNSET_VARIABLE": null
+        }
+    }
+}

--- a/tests/merge_dict/os_agnostic_platforms.json
+++ b/tests/merge_dict/os_agnostic_platforms.json
@@ -1,0 +1,19 @@
+{
+    "in_data": {
+        "unset": [
+            "UNSET_VARIABLE"
+        ],
+        "append": {
+            "SHARED": "all"
+        }
+    },
+    "out_data": {
+        "os_specific": true,
+        "reactos": {
+            "SHARED": [
+                "all"
+            ],
+            "UNSET_VARIABLE": null
+        }
+    }
+}

--- a/tests/merge_dict/os_specific.json
+++ b/tests/merge_dict/os_specific.json
@@ -1,0 +1,79 @@
+{
+    "in_data": {
+        "os_specific": true,
+        "linux": {
+            "unset": [
+                "UNSET_VARIABLE_LIN"
+            ],
+            "set": {
+                "SET_BY_LINUX": "linux_value"
+            },
+            "append": {
+                "LIN_VARIABLE": "append_platform_lin",
+                "SHARED": "linux"
+            }
+        },
+        "windows": {
+            "unset": [
+                "UNSET_VARIABLE_WIN",
+                "UNSET_BY_WINDOWS"
+            ],
+            "append": {
+                "WIN_VARIABLE": "append_platform_win",
+                "SHARED": "windows"
+            }
+        },
+        "*": {
+            "unset": [
+                "UNSET_VARIABLE_ALL"
+            ],
+            "append": {
+                "ALL_VARIABLE": "append_platform_all",
+                "UNSET_BY_WINDOWS": "removed_by_windows",
+                "SET_BY_LINUX": "replaced_only_by_linux",
+                "SHARED": "all"
+            }
+        }
+    },
+    "out_data": {
+        "linux": {
+            "ALL_VARIABLE": [
+                "append_platform_all"
+            ],
+            "LIN_VARIABLE": [
+                "append_platform_lin"
+            ],
+            "SET_BY_LINUX": [
+                "linux_value"
+            ],
+            "SHARED": [
+                "all",
+                "linux"
+            ],
+            "UNSET_BY_WINDOWS": [
+                "removed_by_windows"
+            ],
+            "UNSET_VARIABLE_ALL": null,
+            "UNSET_VARIABLE_LIN": null
+        },
+        "os_specific": true,
+        "windows": {
+            "ALL_VARIABLE": [
+                "append_platform_all"
+            ],
+            "SET_BY_LINUX": [
+                "replaced_only_by_linux"
+            ],
+            "SHARED": [
+                "all",
+                "windows"
+            ],
+            "UNSET_BY_WINDOWS": null,
+            "UNSET_VARIABLE_ALL": null,
+            "UNSET_VARIABLE_WIN": null,
+            "WIN_VARIABLE": [
+                "append_platform_win"
+            ]
+        }
+    }
+}

--- a/tests/merge_dict/os_specific_false.json
+++ b/tests/merge_dict/os_specific_false.json
@@ -1,0 +1,26 @@
+{
+    "in_data": {
+        "os_specific": false,
+        "unset": [
+            "UNSET_VARIABLE"
+        ],
+        "append": {
+            "SHARED": "all"
+        }
+    },
+    "out_data": {
+        "linux": {
+            "SHARED": [
+                "all"
+            ],
+            "UNSET_VARIABLE": null
+        },
+        "os_specific": true,
+        "windows": {
+            "SHARED": [
+                "all"
+            ],
+            "UNSET_VARIABLE": null
+        }
+    }
+}

--- a/tests/merge_dict/os_specific_platforms.json
+++ b/tests/merge_dict/os_specific_platforms.json
@@ -1,0 +1,76 @@
+{
+    "in_data": {
+        "os_specific": true,
+        "linux": {
+            "unset": [
+                "UNSET_VARIABLE_LIN"
+            ],
+            "set": {
+                "SET_BY_LINUX": "linux_value"
+            },
+            "append": {
+                "LIN_VARIABLE": "append_platform_lin",
+                "SHARED": "linux"
+            }
+        },
+        "reactos": {
+            "unset": [
+                "UNSET_VARIABLE_REACTOS"
+            ],
+            "set": {
+                "SET_BY_REACTOS": "reactos_value"
+            },
+            "append": {
+                "REACTOS_VARIABLE": "append_platform_reactos",
+                "SHARED": "reactos"
+            }
+        },
+        "windows": {
+            "unset": [
+                "UNSET_VARIABLE_WIN",
+                "UNSET_BY_WINDOWS"
+            ],
+            "append": {
+                "WIN_VARIABLE": "append_platform_win",
+                "SHARED": "windows"
+            }
+        },
+        "*": {
+            "unset": [
+                "UNSET_VARIABLE_ALL"
+            ],
+            "append": {
+                "ALL_VARIABLE": "append_platform_all",
+                "UNSET_BY_WINDOWS": "removed_by_windows",
+                "SET_BY_LINUX": "replaced_only_by_linux",
+                "SHARED": "all"
+            }
+        }
+    },
+    "out_data": {
+        "os_specific": true,
+        "reactos": {
+            "ALL_VARIABLE": [
+                "append_platform_all"
+            ],
+            "REACTOS_VARIABLE": [
+                "append_platform_reactos"
+            ],
+            "SET_BY_LINUX": [
+                "replaced_only_by_linux"
+            ],
+            "SET_BY_REACTOS": [
+                "reactos_value"
+            ],
+            "SHARED": [
+                "all",
+                "reactos"
+            ],
+            "UNSET_BY_WINDOWS": [
+                "removed_by_windows"
+            ],
+            "UNSET_VARIABLE_ALL": null,
+            "UNSET_VARIABLE_REACTOS": null
+        }
+    }
+}

--- a/tests/merge_dict/test_merge_dict.py
+++ b/tests/merge_dict/test_merge_dict.py
@@ -1,0 +1,64 @@
+import json
+
+import pytest
+
+from hab.merge_dict import MergeDict
+
+
+@pytest.mark.parametrize(
+    "filename,platforms",
+    (
+        # if os_specific is not set, add the variables to all platforms
+        ("os_agnostic.json", None),
+        # If platform is specified, only the requested platforms are returned
+        ("os_agnostic_platforms.json", ("reactos",)),
+        # os_specific is set, so merge "*" with each platform
+        ("os_specific.json", None),
+        # if os_specific is set to False, treat it the same as os_agnostic
+        ("os_specific_false.json", None),
+        # If platform is specified in an os_specific context, only the requested
+        # platforms are returned
+        ("os_specific_platforms.json", ("reactos",)),
+    ),
+)
+def test_apply_platform_wildcards(config_root, filename, platforms):
+    """Test merging of "*" os specific dicts into platform specific dictionaries"""
+    json_path = config_root / "merge_dict" / filename
+
+    with json_path.open() as fle:
+        test_data = json.load(fle)
+
+    # The data to feed the apply_platform_wildcards method
+    in_data = test_data["in_data"]
+    # The output from the apply_platform_wildcards method to check against
+    out_data = test_data["out_data"]
+
+    kwargs = {}
+    if platforms is not None:
+        kwargs["platforms"] = platforms
+
+    merger = MergeDict(**kwargs)
+    result = merger.apply_platform_wildcards(in_data)
+
+    assert result == out_data
+
+
+@pytest.mark.parametrize("filename", ("merge_agnostic.json", "merge_specific.json"))
+def test_merge(config_root, filename):
+    """Test that we can merge multiple "*" dicts into a single dict."""
+    json_path = config_root / "merge_dict" / filename
+
+    with json_path.open() as fle:
+        test_data = json.load(fle)
+
+    # The data to feed the apply_platform_wildcards method
+    file_one = test_data["file_one"]
+    file_two = test_data["file_two"]
+    # The output from the apply_platform_wildcards method to check against
+    out_data = test_data["out_data"]
+
+    merger = MergeDict()
+    result = merger.apply_platform_wildcards(file_one)
+    result = merger.apply_platform_wildcards(file_two, output=result)
+
+    assert result == out_data

--- a/tests/merge_dict/test_merge_dict.py
+++ b/tests/merge_dict/test_merge_dict.py
@@ -1,7 +1,9 @@
 import json
+import os
 
 import pytest
 
+from hab import utils
 from hab.merge_dict import MergeDict
 
 
@@ -21,7 +23,7 @@ from hab.merge_dict import MergeDict
         ("os_specific_platforms.json", ("reactos",)),
     ),
 )
-def test_apply_platform_wildcards(config_root, filename, platforms):
+def test_apply_platform_wildcards(config_root, resolver, filename, platforms):
     """Test merging of "*" os specific dicts into platform specific dictionaries"""
     json_path = config_root / "merge_dict" / filename
 
@@ -36,11 +38,40 @@ def test_apply_platform_wildcards(config_root, filename, platforms):
     kwargs = {}
     if platforms is not None:
         kwargs["platforms"] = platforms
+        kwargs["site"] = resolver.site
 
     merger = MergeDict(**kwargs)
     result = merger.apply_platform_wildcards(in_data)
 
     assert result == out_data
+
+
+def test_path_split(monkeypatch):
+    # Check the pathsep argument is respected
+    assert utils.path_split("a:b", pathsep=":") == ['a', 'b']
+    assert utils.path_split("a;b", pathsep=";") == ['a', 'b']
+    assert utils.path_split("a-b", pathsep="-") == ['a', 'b']
+
+    # Check if pathsep argument is not passed, the current os is respected
+    # Windows
+    monkeypatch.setattr(os, 'pathsep', ";")
+    assert utils.path_split("a;b") == ['a', 'b']
+    assert utils.path_split("a:b") == ['a:b']
+    # Linux/Mac
+    monkeypatch.setattr(os, 'pathsep', ":")
+    assert utils.path_split("a;b") == ['a;b']
+    assert utils.path_split("a:b") == ['a', 'b']
+
+    # If a single windows file path is passed on linux/mac it's not split on ":"
+    assert utils.path_split(r"Z:\test", pathsep=":") == [r'Z:\test']
+    # TODO: This test covers the current behavior but ideally we can figure out
+    # a way to prevent splitting the two windows file paths.
+    assert utils.path_split(r"Z:\test:X:test", pathsep=":") == [
+        "Z",
+        r"\test",
+        "X",
+        "test",
+    ]
 
 
 @pytest.mark.parametrize("filename", ("merge_agnostic.json", "merge_specific.json"))

--- a/tests/site/site_left.json
+++ b/tests/site/site_left.json
@@ -1,0 +1,25 @@
+{
+    "prepend": {
+        "test_paths": [
+            "left_prepend"
+        ]
+    },
+    "append": {
+        "test_paths": [
+            "left_append"
+        ],
+        "platform_path_maps": {
+            "host": {
+                "linux": "host-linux_left",
+                "windows": "host-windows_left"
+            },
+            "shared": {
+                "linux": "shared-linux_left",
+                "windows": "shared-windows_left"
+            }
+        }
+    },
+    "set": {
+        "set_value": "left"
+    }
+}

--- a/tests/site/site_middle.json
+++ b/tests/site/site_middle.json
@@ -1,0 +1,25 @@
+{
+    "prepend": {
+        "test_paths": [
+            "middle_prepend"
+        ]
+    },
+    "append": {
+        "test_paths": [
+            "middle_append"
+        ],
+        "platform_path_maps": {
+            "host": {
+                "linux": "host-linux_middle",
+                "windows": "host-windows_middle"
+            },
+            "mid": {
+                "linux": "mid-linux_middle",
+                "windows": "mid-windows_middle"
+            }
+        }
+    },
+    "set": {
+        "set_value": "middle"
+    }
+}

--- a/tests/site/site_right.json
+++ b/tests/site/site_right.json
@@ -1,0 +1,25 @@
+{
+    "prepend": {
+        "test_paths": [
+            "right_prepend"
+        ]
+    },
+    "append": {
+        "test_paths": [
+            "right_append"
+        ],
+        "platform_path_maps": {
+            "host": {
+                "linux": "host-linux_right",
+                "windows": "host-windows_right"
+            },
+            "net": {
+                "linux": "net-linux_right",
+                "windows": "net-windows_right"
+            }
+        }
+    },
+    "set": {
+        "set_value": "right"
+    }
+}

--- a/tests/site_main.json
+++ b/tests/site_main.json
@@ -5,7 +5,19 @@
         ],
         "distro_paths": [
             "{relative_root}/distros/*"
-        ]
+        ],
+        "platform_path_maps": {
+            "host-root": {
+                "linux": "/usr/local/host/root",
+                "mac": "/usr/local/mac/host/root",
+                "windows": "c:\\host\\root"
+            },
+            "network-mount": {
+                "linux": "/mnt/shared_resources",
+                "mac": "/mnt/mac/shared_resources",
+                "windows": "\\\\example\\shared_resources"
+            }
+        }
     },
     "set": {
         "generic_value": false,

--- a/tests/site_main.json
+++ b/tests/site_main.json
@@ -9,6 +9,10 @@
     },
     "set": {
         "generic_value": false,
-        "filename": "site_main.json"
+        "filename": "site_main.json",
+        "platforms": [
+            "windows",
+            "linux"
+        ]
     }
 }

--- a/tests/site_os_specific.json
+++ b/tests/site_os_specific.json
@@ -1,6 +1,9 @@
 {
     "os_specific": true,
     "linux": {
+        "set":{
+            "platforms": ["windows", "linux"]
+        },
         "append": {
             "config_paths": [
                 "config/path/linux"
@@ -10,7 +13,23 @@
             ]
         }
     },
+    "mac": {
+        "set":{
+            "platforms": ["mac", "linux"]
+        },
+        "append": {
+            "config_paths": [
+                "config/path/mac"
+            ],
+            "distro_paths": [
+                "distro/path/mac"
+            ]
+        }
+    },
     "windows": {
+        "set":{
+            "platforms": ["windows", "mac"]
+        },
         "append": {
             "config_paths": [
                 "config\\path\\windows"

--- a/tests/site_os_specific.json
+++ b/tests/site_os_specific.json
@@ -3,20 +3,20 @@
     "linux": {
         "append": {
             "config_paths": [
-                "config/path"
+                "config/path/linux"
             ],
             "distro_paths": [
-                "distro/path"
+                "distro/path/linux"
             ]
         }
     },
     "windows": {
         "append": {
             "config_paths": [
-                "config\\path"
+                "config\\path\\windows"
             ],
             "distro_paths": [
-                "distro\\path"
+                "distro\\path\\windows"
             ]
         }
     }

--- a/tests/site_override.json
+++ b/tests/site_override.json
@@ -2,7 +2,14 @@
     "append": {
         "distro_paths": [
             "{relative_root}/duplicates/distros_1/*"
-        ]
+        ],
+        "platform_path_maps": {
+            "network-mount": {
+                "linux": "/mnt/work/shared_resources",
+                "mac": "/mnt/work/mac/shared_resources",
+                "windows": "g:\\work\\shared_resources"
+            }
+        }
     },
     "set": {
         "generic_value": true,

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -1,0 +1,114 @@
+import pytest
+
+from hab import NotSet, utils
+from hab.parsers import UnfrozenConfig
+from hab.utils import dumps_json, json
+
+
+def test_json_dumps():
+    """Check that dumps_json returns the expected results for non-standard
+    objects."""
+    data = {"NotSet": NotSet}
+    assert dumps_json(data) == '{"NotSet": null}'
+    assert dumps_json(data, indent=2) == '\n'.join(
+        [
+            '{',
+            '  "NotSet": null',
+            '}',
+        ]
+    )
+
+
+def test_freeze(config_root, resolver):
+    cfg = resolver.resolve("not_set/distros")
+    # Ensure consistent testing across platforms. cfg has the current os's
+    # file paths instead of what is stored in frozen.json
+    cfg.frozen_data["aliases"]["linux"]["dcc"] = "TEST_DIR_NAME//the_dcc"
+    cfg.frozen_data["aliases"]["windows"]["dcc"] = "TEST_DIR_NAME\\the_dcc.exe"
+
+    ret = cfg.freeze()
+    check_file = config_root / "frozen.json"
+    check = json.load(check_file.open())
+    assert ret == check
+
+
+def test_unfreeze(config_root, resolver):
+    check_file = config_root / "frozen.json"
+
+    # Note: For this test, we don't need to worry about "{config_root}" templates.
+    frozen_config = utils.json.load(check_file.open())
+    cfg = UnfrozenConfig(frozen_config, resolver)
+
+    assert cfg.context == frozen_config["context"]
+    assert cfg.name == frozen_config["name"]
+    assert cfg.uri == frozen_config["uri"]
+    assert (
+        cfg.frozen_data["aliases"]["linux"]["dcc"]
+        == frozen_config["aliases"]["linux"]["dcc"]
+    )
+    assert (
+        cfg.frozen_data["aliases"]["windows"]["dcc"]
+        == frozen_config["aliases"]["windows"]["dcc"]
+    )
+
+    assert cfg.versions == frozen_config["versions"]
+    assert cfg.frozen_data["environment"] == frozen_config["environment"]
+
+    # Check various class overrides
+    assert cfg._dump_versions(cfg.versions) == sorted(frozen_config["versions"])
+    assert cfg.aliases == frozen_config["aliases"][cfg._platform]
+    assert "dcc" in cfg.aliases
+    assert cfg.fullpath == "not_set/distros"
+
+
+def test_decode_freeze(config_root, resolver):
+    check_file = config_root / "frozen_no_distros.json"
+    checks = utils.json.load(check_file.open())
+    v1 = checks["version1"]
+    raw = checks["raw"]
+
+    # Check that a v1 freeze is decoded correctly
+    assert utils.decode_freeze(v1) == raw
+    # Check that padded versions are also supported
+    assert utils.decode_freeze(f'v01:{v1[3:]}') == raw
+
+    # Check that non-versioned freeze strings raise an helpful exception
+    for check in (
+        # Missing `v1:`
+        v1[3:],
+        # Missing `v'
+        f'1:{v1[3:]}',
+    ):
+        with pytest.raises(ValueError) as excinfo:
+            utils.decode_freeze(check)
+        assert (
+            str(excinfo.value)
+            == "Missing freeze version information in format `v0:...`"
+        )
+
+    # Check that versions other than numbers raise a helpful exception
+    with pytest.raises(ValueError) as excinfo:
+        utils.decode_freeze(f'vINVALID:{v1[3:]}')
+    assert str(excinfo.value) == 'Version INVALID is not valid.'
+
+    # check that other version encodings return nothing
+    assert utils.decode_freeze(f'v2:{v1[3:]}') is None
+    assert utils.decode_freeze(f'v0:{v1[3:]}') is None
+
+
+def test_encode_freeze(config_root, resolver):
+    cfg = resolver.resolve('not_set/no_distros')
+    check_file = config_root / "frozen_no_distros.json"
+    checks = utils.json.load(check_file.open())
+
+    # Check that the dict contains the expected contents
+    freeze = cfg.freeze()
+    assert freeze == checks["raw"]
+
+    # Check that version 1 encoding is correct
+    version1 = utils.encode_freeze(freeze, version=1)
+    assert version1 == checks["version1"]
+
+    # Check that other version encodings return nothing
+    assert utils.encode_freeze(freeze, version=0) is None
+    assert utils.encode_freeze(freeze, version=2) is None

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -7,9 +7,9 @@ import anytree
 import pytest
 from packaging.version import Version
 
-from hab import utils
+from hab import NotSet, utils
 from hab.errors import DuplicateJsonError, InvalidVersionError, _IgnoredVersionError
-from hab.parsers import Config, DistroVersion, NotSet
+from hab.parsers import Config, DistroVersion
 
 
 def test_distro_parse(config_root, resolver):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -218,15 +218,15 @@ def test_dump(resolver):
     pre = ["name:  child", "uri:  not_set/child"]
     post = ["inherits:  True"]
     env = [
-        "environment:  UNSET_VARIABLE:  None",
+        "environment:  FMT_FOR_OS:  a{;}b;c:{PATH!e}{;}d",
         "              TEST:  case",
-        "              FMT_FOR_OS:  a{;}b;c:{PATH!e}{;}d",
+        "              UNSET_VARIABLE:  None",
     ]
 
     env_config = [
-        "environment_config:  unset:  UNSET_VARIABLE",
-        "                     set:  TEST:  case",
-        "                           FMT_FOR_OS:  a{;}b;c:{PATH!e}{;}d",
+        "environment_config:  set:  FMT_FOR_OS:  a{;}b;c:{PATH!e}{;}d",
+        "                           TEST:  case",
+        "                     unset:  UNSET_VARIABLE",
     ]
     cfg = resolver.closest_config("not_set/child")
     header = f"Dump of {type(cfg).__name__}('{cfg.fullpath}')"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -6,9 +6,8 @@ import anytree
 import pytest
 from packaging.requirements import Requirement
 
-from hab import Resolver, Site, utils
+from hab import NotSet, Resolver, Site, utils
 from hab.errors import MaxRedirectError
-from hab.parsers import NotSet
 from hab.solvers import Solver
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -113,6 +113,7 @@ def test_dump_forest(resolver):
             "    |-- hab.parsers.config.Config('not_set/env_path_set')",
             "    |-- hab.parsers.config.Config('not_set/env_path_unset')",
             "    |-- hab.parsers.config.Config('not_set/distros')",
+            "    |-- hab.parsers.config.Config('not_set/no_distros')",
             "    |-- hab.parsers.config.Config('not_set/no_env')",
             "    +-- hab.parsers.config.Config('not_set/os')",
             "place-holder",

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -110,6 +110,7 @@ def test_dump_forest(resolver):
             "    hab.parsers.config.Config('not_set')",
             "    |-- hab.parsers.config.Config('not_set/child')",
             "    |-- hab.parsers.config.Config('not_set/env1')",
+            "    |-- hab.parsers.config.Config('not_set/env_path_hab_uri')",
             "    |-- hab.parsers.config.Config('not_set/env_path_set')",
             "    |-- hab.parsers.config.Config('not_set/env_path_unset')",
             "    |-- hab.parsers.config.Config('not_set/distros')",

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,16 +1,9 @@
 import sys
-from pathlib import Path
 
 import colorama
 import pytest
 
 from hab import Site, utils
-
-
-def check_path_list(paths, checks):
-    """Check that a list of path strings match a list of Path objects."""
-    for i, check in enumerate(checks):
-        assert Path(paths[i]) == check
 
 
 def test_environment_variables(config_root, monkeypatch):
@@ -34,20 +27,20 @@ def test_resolve_path(config_root):
     assert site.get("filename") == ["site_main.json"]
 
 
-def test_resolve_paths(config_root):
+def test_resolve_paths(config_root, helpers):
     # Check that values specified by additional files overwrite the previous values
     paths = [config_root / "site_main.json", config_root / "site_override.json"]
     site = Site(paths)
     assert site.get("generic_value") is True
     assert site.get("override") == ["site_override.json"]
     assert site.get("filename") == ["site_override.json"]
-    assert site.get("platforms") == ["windows", "mac", "linux"]
+    assert site.get("platforms") == ["windows", "linux"]
 
     # Check that the paths defined in multiple site files are correctly added
     assert len(site.get("config_paths")) == 1
-    check_path_list(site.get("config_paths"), [config_root / "configs" / "*"])
+    helpers.check_path_list(site.get("config_paths"), [config_root / "configs" / "*"])
     assert len(site.get("distro_paths")) == 2
-    check_path_list(
+    helpers.check_path_list(
         site.get("distro_paths"),
         (
             config_root / "distros" / "*",
@@ -56,7 +49,7 @@ def test_resolve_paths(config_root):
     )
 
 
-def test_resolve_paths_reversed(config_root):
+def test_resolve_paths_reversed(config_root, helpers):
     # Check that values specified by additional files overwrite the previous values
     paths = [config_root / "site_override.json", config_root / "site_main.json"]
     site = Site(paths)
@@ -66,9 +59,9 @@ def test_resolve_paths_reversed(config_root):
 
     # Check that the paths defined in multiple site files are correctly added
     assert len(site.get("config_paths")) == 1
-    check_path_list(site.get("config_paths"), [config_root / "configs" / "*"])
+    helpers.check_path_list(site.get("config_paths"), [config_root / "configs" / "*"])
     assert len(site.get("distro_paths")) == 2
-    check_path_list(
+    helpers.check_path_list(
         site.get("distro_paths"),
         (
             config_root / "duplicates" / "distros_1" / "*",

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -41,6 +41,7 @@ def test_resolve_paths(config_root):
     assert site.get("generic_value") is True
     assert site.get("override") == ["site_override.json"]
     assert site.get("filename") == ["site_override.json"]
+    assert site.get("platforms") == ["windows", "mac", "linux"]
 
     # Check that the paths defined in multiple site files are correctly added
     assert len(site.get("config_paths")) == 1
@@ -124,6 +125,21 @@ def test_os_specific_linux(monkeypatch, config_root):
 
     assert site.get("config_paths") == ["config/path/linux"]
     assert site.get("distro_paths") == ["distro/path/linux"]
+    assert site.get("platforms") == ["windows", "linux"]
+
+
+def test_os_specific_mac(monkeypatch, config_root):
+    """Check that if "os_specific" is set to true, only vars for the current
+    os are resolved."""
+    # Simulate running on a mac platform.
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    paths = [config_root / "site_os_specific.json"]
+    site = Site(paths)
+
+    assert site.get("config_paths") == ["config/path/mac"]
+    assert site.get("distro_paths") == ["distro/path/mac"]
+    assert site.get("platforms") == ["mac", "linux"]
 
 
 def test_os_specific_win(monkeypatch, config_root):
@@ -137,3 +153,4 @@ def test_os_specific_win(monkeypatch, config_root):
 
     assert site.get("config_paths") == ["config\\path\\windows"]
     assert site.get("distro_paths") == ["distro\\path\\windows"]
+    assert site.get("platforms") == ["windows", "mac"]

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import PurePosixPath, PureWindowsPath
 
 import colorama
 import pytest
@@ -18,56 +19,59 @@ def test_environment_variables(config_root, monkeypatch):
     assert site.paths == paths
 
 
-def test_resolve_path(config_root):
-    # Check that the correct values are resolved when processing a single result
-    paths = [config_root / "site_main.json"]
-    site = Site(paths)
-    assert site.get("generic_value") is False
-    assert "override" not in site
-    assert site.get("filename") == ["site_main.json"]
+class TestResolvePaths:
+    def test_path(self, config_root):
+        # Check that the correct values are resolved when processing a single result
+        paths = [config_root / "site_main.json"]
+        site = Site(paths)
+        assert site.get("generic_value") is False
+        assert "override" not in site
+        assert site.get("filename") == ["site_main.json"]
 
+    def test_paths(self, config_root, helpers):
+        # Check that values specified by additional files overwrite the previous values
+        paths = [config_root / "site_main.json", config_root / "site_override.json"]
+        site = Site(paths)
+        assert site.get("generic_value") is True
+        assert site.get("override") == ["site_override.json"]
+        assert site.get("filename") == ["site_override.json"]
+        assert site.get("platforms") == ["windows", "linux"]
 
-def test_resolve_paths(config_root, helpers):
-    # Check that values specified by additional files overwrite the previous values
-    paths = [config_root / "site_main.json", config_root / "site_override.json"]
-    site = Site(paths)
-    assert site.get("generic_value") is True
-    assert site.get("override") == ["site_override.json"]
-    assert site.get("filename") == ["site_override.json"]
-    assert site.get("platforms") == ["windows", "linux"]
+        # Check that the paths defined in multiple site files are correctly added
+        assert len(site.get("config_paths")) == 1
+        helpers.check_path_list(
+            site.get("config_paths"), [config_root / "configs" / "*"]
+        )
+        assert len(site.get("distro_paths")) == 2
+        helpers.check_path_list(
+            site.get("distro_paths"),
+            (
+                config_root / "distros" / "*",
+                config_root / "duplicates" / "distros_1" / "*",
+            ),
+        )
 
-    # Check that the paths defined in multiple site files are correctly added
-    assert len(site.get("config_paths")) == 1
-    helpers.check_path_list(site.get("config_paths"), [config_root / "configs" / "*"])
-    assert len(site.get("distro_paths")) == 2
-    helpers.check_path_list(
-        site.get("distro_paths"),
-        (
-            config_root / "distros" / "*",
-            config_root / "duplicates" / "distros_1" / "*",
-        ),
-    )
+    def test_paths_reversed(self, config_root, helpers):
+        # Check that values specified by additional files overwrite the previous values
+        paths = [config_root / "site_override.json", config_root / "site_main.json"]
+        site = Site(paths)
+        assert site.get("generic_value") is False
+        assert site.get("override") == ["site_override.json"]
+        assert site.get("filename") == ["site_main.json"]
 
-
-def test_resolve_paths_reversed(config_root, helpers):
-    # Check that values specified by additional files overwrite the previous values
-    paths = [config_root / "site_override.json", config_root / "site_main.json"]
-    site = Site(paths)
-    assert site.get("generic_value") is False
-    assert site.get("override") == ["site_override.json"]
-    assert site.get("filename") == ["site_main.json"]
-
-    # Check that the paths defined in multiple site files are correctly added
-    assert len(site.get("config_paths")) == 1
-    helpers.check_path_list(site.get("config_paths"), [config_root / "configs" / "*"])
-    assert len(site.get("distro_paths")) == 2
-    helpers.check_path_list(
-        site.get("distro_paths"),
-        (
-            config_root / "duplicates" / "distros_1" / "*",
-            config_root / "distros" / "*",
-        ),
-    )
+        # Check that the paths defined in multiple site files are correctly added
+        assert len(site.get("config_paths")) == 1
+        helpers.check_path_list(
+            site.get("config_paths"), [config_root / "configs" / "*"]
+        )
+        assert len(site.get("distro_paths")) == 2
+        helpers.check_path_list(
+            site.get("distro_paths"),
+            (
+                config_root / "duplicates" / "distros_1" / "*",
+                config_root / "distros" / "*",
+            ),
+        )
 
 
 def test_path_in_raise(config_root):
@@ -107,43 +111,189 @@ def test_dump(config_root):
         assert check.format(green="", reset="") in result
 
 
-def test_os_specific_linux(monkeypatch, config_root):
-    """Check that if "os_specific" is set to true, only vars for the current
-    os are resolved."""
-    # Simulate running on a linux platform.
-    monkeypatch.setattr(sys, "platform", "linux")
+class TestOsSpecific:
+    def test_linux(self, monkeypatch, config_root):
+        """Check that if "os_specific" is set to true, only vars for the current
+        os are resolved."""
+        # Simulate running on a linux platform.
+        monkeypatch.setattr(sys, "platform", "linux")
 
-    paths = [config_root / "site_os_specific.json"]
-    site = Site(paths)
+        paths = [config_root / "site_os_specific.json"]
+        site = Site(paths)
 
-    assert site.get("config_paths") == ["config/path/linux"]
-    assert site.get("distro_paths") == ["distro/path/linux"]
-    assert site.get("platforms") == ["windows", "linux"]
+        assert site.get("config_paths") == ["config/path/linux"]
+        assert site.get("distro_paths") == ["distro/path/linux"]
+        assert site.get("platforms") == ["windows", "linux"]
+
+    def test_mac(self, monkeypatch, config_root):
+        """Check that if "os_specific" is set to true, only vars for the current
+        os are resolved."""
+        # Simulate running on a mac platform.
+        monkeypatch.setattr(sys, "platform", "darwin")
+
+        paths = [config_root / "site_os_specific.json"]
+        site = Site(paths)
+
+        assert site.get("config_paths") == ["config/path/mac"]
+        assert site.get("distro_paths") == ["distro/path/mac"]
+        assert site.get("platforms") == ["mac", "linux"]
+
+    def test_win(self, monkeypatch, config_root):
+        """Check that if "os_specific" is set to true, only vars for the current
+        os are resolved."""
+        # Simulate running on a windows platform
+        monkeypatch.setattr(sys, "platform", "win32")
+
+        paths = [config_root / "site_os_specific.json"]
+        site = Site(paths)
+
+        assert site.get("config_paths") == ["config\\path\\windows"]
+        assert site.get("distro_paths") == ["distro\\path\\windows"]
+        assert site.get("platforms") == ["windows", "mac"]
 
 
-def test_os_specific_mac(monkeypatch, config_root):
-    """Check that if "os_specific" is set to true, only vars for the current
-    os are resolved."""
-    # Simulate running on a mac platform.
-    monkeypatch.setattr(sys, "platform", "darwin")
+class TestPlatformPathMap:
+    def test_linux(self, monkeypatch, config_root):
+        """For linux check that various inputs are correctly processed."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        site = Site([config_root / "site_main.json"])
 
-    paths = [config_root / "site_os_specific.json"]
-    site = Site(paths)
+        # Check exact path matches are translated
+        out = site.platform_path_map("/usr/local/host/root", platform="linux")
+        assert out == "/usr/local/host/root"
+        out = site.platform_path_map("/usr/local/host/root/extra", platform="linux")
+        assert out == "/usr/local/host/root/extra"
 
-    assert site.get("config_paths") == ["config/path/mac"]
-    assert site.get("distro_paths") == ["distro/path/mac"]
-    assert site.get("platforms") == ["mac", "linux"]
+        out = site.platform_path_map("/usr/local/host/root", platform="mac")
+        assert out == "/usr/local/mac/host/root"
+        out = site.platform_path_map("/usr/local/host/root/extra", platform="mac")
+        assert out == "/usr/local/mac/host/root/extra"
+
+        out = site.platform_path_map("/usr/local/host/root", platform="windows")
+        assert out == r"c:\host\root"
+        out = site.platform_path_map("/usr/local/host/root/extra", platform="windows")
+        assert out == r"c:\host\root\extra"
+
+    def test_win(self, monkeypatch, config_root):
+        """For windows check that various inputs are correctly processed."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        site = Site([config_root / "site_main.json"])
+
+        # Check exact path matches are translated
+        out = site.platform_path_map(r"c:\host\root", platform="linux")
+        assert out == "/usr/local/host/root"
+        out = site.platform_path_map(r"c:\host/root/extra", platform="linux")
+        assert out == "/usr/local/host/root/extra"
+        out = site.platform_path_map("c:/host/root", platform="linux")
+        assert out == "/usr/local/host/root"
+
+        out = site.platform_path_map(r"c:\host\root", platform="mac")
+        assert out == "/usr/local/mac/host/root"
+        out = site.platform_path_map(r"c:\host\root\extra", platform="mac")
+        assert out == "/usr/local/mac/host/root/extra"
+        out = site.platform_path_map("c:/host/root", platform="mac")
+        assert out == "/usr/local/mac/host/root"
+
+        out = site.platform_path_map(r"c:\host\root", platform="windows")
+        assert out == r"c:\host\root"
+        out = site.platform_path_map(r"c:\host\root\extra", platform="windows")
+        assert out == r"c:\host\root\extra"
+        out = site.platform_path_map("c:/host/root", platform="windows")
+        assert out == r"c:\host\root"
 
 
-def test_os_specific_win(monkeypatch, config_root):
-    """Check that if "os_specific" is set to true, only vars for the current
-    os are resolved."""
-    # Simulate running on a windows platform
-    monkeypatch.setattr(sys, "platform", "win32")
+class TestPlatformPathMapDict:
+    def assert_main(self, site):
+        """Used by several tests to assert site_main.json's "network-mount"
+        settings are in use.
+        """
+        assert site["platform_path_maps"]["network-mount"]["linux"] == PurePosixPath(
+            "/mnt/shared_resources"
+        )
+        assert site["platform_path_maps"]["network-mount"]["mac"] == PurePosixPath(
+            "/mnt/mac/shared_resources"
+        )
+        assert site["platform_path_maps"]["network-mount"][
+            "windows"
+        ] == PureWindowsPath("\\\\example\\shared_resources")
 
-    paths = [config_root / "site_os_specific.json"]
-    site = Site(paths)
+    def assert_override(self, site):
+        """Used by several tests to assert site_override.json's "network-mount"
+        settings are in use.
+        """
+        assert site["platform_path_maps"]["network-mount"]["linux"] == PurePosixPath(
+            "/mnt/work/shared_resources"
+        )
+        assert site["platform_path_maps"]["network-mount"]["mac"] == PurePosixPath(
+            "/mnt/work/mac/shared_resources"
+        )
+        assert site["platform_path_maps"]["network-mount"][
+            "windows"
+        ] == PureWindowsPath("g:\\work\\shared_resources")
 
-    assert site.get("config_paths") == ["config\\path\\windows"]
-    assert site.get("distro_paths") == ["distro\\path\\windows"]
-    assert site.get("platforms") == ["windows", "mac"]
+    def test_main(self, config_root):
+        """Test that all platform_path_map settings in site_main.json were found."""
+        paths = [config_root / "site_main.json"]
+        site = Site(paths)
+
+        assert site["platform_path_maps"]["host-root"]["linux"] == PurePosixPath(
+            "/usr/local/host/root"
+        )
+        assert site["platform_path_maps"]["host-root"]["mac"] == PurePosixPath(
+            "/usr/local/mac/host/root"
+        )
+        assert site["platform_path_maps"]["host-root"]["windows"] == PureWindowsPath(
+            "c:\\host\\root"
+        )
+
+        self.assert_main(site)
+
+    def test_override(self, config_root):
+        """Test that all platform_path_map settings in site_override.json were found."""
+        paths = [config_root / "site_override.json"]
+        site = Site(paths)
+
+        # host-root is not specified in this site file.
+        assert "host-root" not in site["platform_path_maps"]
+
+        self.assert_override(site)
+
+    def test_merged(self, config_root):
+        """Test that the correct platform_path_map settings are resolved when using
+        both site_main.json and site_override.json."""
+        paths = [config_root / "site_main.json", config_root / "site_override.json"]
+        site = Site(paths)
+
+        # This is only specified in site_main.json
+        assert site["platform_path_maps"]["host-root"]["linux"] == PurePosixPath(
+            "/usr/local/host/root"
+        )
+        assert site["platform_path_maps"]["host-root"]["mac"] == PurePosixPath(
+            "/usr/local/mac/host/root"
+        )
+        assert site["platform_path_maps"]["host-root"]["windows"] == PureWindowsPath(
+            "c:\\host\\root"
+        )
+
+        # The right-most site file's settings are loaded when both have the same keys
+        self.assert_override(site)
+
+    def test_reversed(self, config_root):
+        """Test that the correct platform_path_map settings are resolved when using
+        both site_main.json and site_override.json."""
+        paths = [config_root / "site_override.json", config_root / "site_main.json"]
+        site = Site(paths)
+
+        # This is only specified in site_main.json
+        assert site["platform_path_maps"]["host-root"]["linux"] == PurePosixPath(
+            "/usr/local/host/root"
+        )
+        assert site["platform_path_maps"]["host-root"]["mac"] == PurePosixPath(
+            "/usr/local/mac/host/root"
+        )
+        assert site["platform_path_maps"]["host-root"]["windows"] == PureWindowsPath(
+            "c:\\host\\root"
+        )
+
+        # The right-most site file's settings are loaded when both have the same keys
+        self.assert_main(site)

--- a/tox.ini
+++ b/tox.ini
@@ -13,16 +13,17 @@ deps =
     pytest
     json5: pyjson5
 commands =
-    # Ensure the version.py file is created
-    python setup.py egg_info
-
     coverage run --append -m pytest {posargs:tests/}
 
 [testenv:begin]
 basepython = python3
 deps =
     coverage
-commands = coverage erase
+commands =
+    # Ensure the version.py file is created
+    python setup.py egg_info
+
+    coverage erase
 
 [testenv:end]
 basepython = python3


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

1. Add ability to save out the current resolved environment in a way that can be restored in a new instance of hab. This can be used to ensure that when running a job on a farm it is run with the same settings as when the user submitted it even if the configuration was changed before the farm picked up the farm job if you just relied on the URI. This frozen config should be able to be restored on another platform.
2. Add support for platform specific site settings.
3. Address some issues with merging environment variables when flattening them.

TODO: Add support for de-duplicating env vars and aliases that are the same across all platforms.