### PR TITLE
User friendly cli error output

### DIFF
--- a/hab/errors.py
+++ b/hab/errors.py
@@ -46,5 +46,5 @@ class InvalidVersionError(LookupError):
     def __str__(self):
         ret = self.message.format(filename=self.filename)
         if self.error:
-            ret = f'{self.error}\n{ret}'
+            ret = f'[{type(self.error).__name__}] {self.error}\n{ret}'
         return ret

--- a/hab/parsers/distro_version.py
+++ b/hab/parsers/distro_version.py
@@ -76,6 +76,9 @@ class DistroVersion(HabBase):
                             )
                         ) from None
                     raise InvalidVersionError(self.filename) from None
+                except Exception as error:
+                    # To make debugging easier include the original exception
+                    raise InvalidVersionError(self.filename, error=error) from None
 
         # The name should be the version == specifier.
         self.distro_name = data.get("name")

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -63,7 +63,9 @@ def test_distro_version_resolve(config_root, resolver, helpers, monkeypatch):
         m.setitem(sys.modules, "setuptools_scm", None)
         with pytest.raises(InvalidVersionError) as excinfo:
             app.load(path)
-    assert str(excinfo.value).startswith("import of setuptools_scm halted")
+    assert str(excinfo.value).startswith(
+        "[ModuleNotFoundError] import of setuptools_scm halted"
+    )
 
     # Test that setuptools_scm is able to resolve the version.
     # This env var forces setuptools_scm to this version so we don't have to


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
The cli now reports errors in a more user friendly and easier to report format by default. You can still enable full tracebacks with `hab -v ...`.