### PR TITLE
Bash on windows now supports modifying existing env vars

### DIFF
--- a/hab/formatter.py
+++ b/hab/formatter.py
@@ -1,3 +1,4 @@
+import os
 import string
 
 from . import utils
@@ -38,7 +39,7 @@ class Formatter(string.Formatter):
         # Using bash on windows
         'shwin': {
             'env_var': '${}',
-            ';': ';',
+            ';': ':',
         },
         # Delay the format for future calls. This allows us to process the environment
         # without changing these, and then when write_script is called the target
@@ -96,8 +97,6 @@ class Formatter(string.Formatter):
         still allows us to override them if required
         """
         ret = dict(self.shell_formats[self.language], **kwargs)
-        import os
-
         ret = dict(os.environ, **ret)
         return ret
 

--- a/hab/templates/config.sh
+++ b/hab/templates/config.sh
@@ -4,7 +4,7 @@ export PS1="[{{ hab_cfg.uri }}] $PS1"
 # Setting global environment variables:
 {% for key, value in hab_cfg.environment.items() %}
 {% if value %}
-    {% set value = utils.Platform.collapse_paths(value) %}
+    {% set value = utils.Platform.collapse_paths(value, ext=ext) %}
     {% set value = formatter.format(value, key=key, value=value) %}
 export {{ key }}="{{ value }}"
 {% else %}
@@ -27,7 +27,7 @@ function {{ alias }}() {
     hab_bac_{{ alias_norm }}=`export -p`
     {% for k, v in alias_env.items() %}
     {% if v %}
-        {% set v = utils.Platform.collapse_paths(v) %}
+        {% set v = utils.Platform.collapse_paths(v, ext=ext) %}
         {% set v = formatter.format(v, key=key, value=v) %}
     export {{ k }}="{{ v }}"
     {% else %}

--- a/tests/distros/aliased/2.0/.hab.json
+++ b/tests/distros/aliased/2.0/.hab.json
@@ -17,7 +17,7 @@
                     "cmd": ["python", "{relative_root}/list_vars.py"],
                     "environment": {
                         "append": {
-                            "PATH": ["{PATH!e}", "{relative_root}/test"]
+                            "PATH": ["{PATH!e}", "{relative_root}/PATH/env/with  spaces"]
                         }
                     }
                 }
@@ -60,7 +60,7 @@
                     "cmd": ["python", "{relative_root}/list_vars.py"],
                     "environment": {
                         "append": {
-                            "PATH": ["{PATH!e}", "{relative_root}/test"]
+                            "PATH": ["{PATH!e}", "{relative_root}/PATH/env/with  spaces"]
                         }
                     }
                 }

--- a/tests/distros/aliased/2.0/list_vars.py
+++ b/tests/distros/aliased/2.0/list_vars.py
@@ -22,4 +22,10 @@ print_var("ALIASED_GLOBAL_C")
 print_var("ALIASED_GLOBAL_D")
 print_var("ALIASED_GLOBAL_E")
 print_var("ALIASED_LOCAL")
+print("")
+
+print(' PATH env var '.center(80, '-'))
+for p in os.environ["PATH"].split(os.path.pathsep):
+    print(p)
+
 print(''.center(80, '-'))

--- a/tests/reference_scripts/bat_activate/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_activate/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/test"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/bat_activate_launch/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_activate_launch/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/test"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/bat_env/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_env/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/test"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/bat_env_launch/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_env_launch/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/test"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/bat_launch/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_launch/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/test"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/bat_launch_args/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_launch_args/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/test"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/ps1_activate/hab_config.ps1
+++ b/tests/reference_scripts/ps1_activate/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/test"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/ps1_activate_launch/hab_config.ps1
+++ b/tests/reference_scripts/ps1_activate_launch/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/test"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/ps1_env/hab_config.ps1
+++ b/tests/reference_scripts/ps1_env/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/test"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/ps1_env_launch/hab_config.ps1
+++ b/tests/reference_scripts/ps1_env_launch/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/test"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/ps1_launch/hab_config.ps1
+++ b/tests/reference_scripts/ps1_launch/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/test"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/ps1_launch_args/hab_config.ps1
+++ b/tests/reference_scripts/ps1_launch_args/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/test"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/sh_linux_activate/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_activate/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_linux_activate_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_activate_launch/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_linux_env/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_env/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_linux_env_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_env_launch/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_linux_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_launch/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_linux_launch_args/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_launch_args/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_win_activate/hab_config.sh
+++ b/tests/reference_scripts/sh_win_activate/hab_config.sh
@@ -4,7 +4,7 @@ export PS1="[not_set/child] $PS1"
 # Setting global environment variables:
 unset UNSET_VARIABLE
 export TEST="case"
-export FMT_FOR_OS="a;b;c:$PATH;d"
+export FMT_FOR_OS="a:b;c:$PATH:d"
 unset ALIASED_GLOBAL_E
 export ALIASED_GLOBAL_B="Global B"
 export ALIASED_GLOBAL_C="Global C"
@@ -22,7 +22,7 @@ function as_dict() {
     export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -37,10 +37,10 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH;{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -52,7 +52,7 @@ function inherited() {
 export -f inherited;
 
 function as_list() {
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 }
 export -f as_list;
 
@@ -65,12 +65,12 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.

--- a/tests/reference_scripts/sh_win_activate_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_win_activate_launch/hab_config.sh
@@ -4,7 +4,7 @@ export PS1="[not_set/child] $PS1"
 # Setting global environment variables:
 unset UNSET_VARIABLE
 export TEST="case"
-export FMT_FOR_OS="a;b;c:$PATH;d"
+export FMT_FOR_OS="a:b;c:$PATH:d"
 unset ALIASED_GLOBAL_E
 export ALIASED_GLOBAL_B="Global B"
 export ALIASED_GLOBAL_C="Global C"
@@ -22,7 +22,7 @@ function as_dict() {
     export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -37,10 +37,10 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH;{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -52,7 +52,7 @@ function inherited() {
 export -f inherited;
 
 function as_list() {
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 }
 export -f as_list;
 
@@ -65,12 +65,12 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.

--- a/tests/reference_scripts/sh_win_env/hab_config.sh
+++ b/tests/reference_scripts/sh_win_env/hab_config.sh
@@ -4,7 +4,7 @@ export PS1="[not_set/child] $PS1"
 # Setting global environment variables:
 unset UNSET_VARIABLE
 export TEST="case"
-export FMT_FOR_OS="a;b;c:$PATH;d"
+export FMT_FOR_OS="a:b;c:$PATH:d"
 unset ALIASED_GLOBAL_E
 export ALIASED_GLOBAL_B="Global B"
 export ALIASED_GLOBAL_C="Global C"
@@ -22,7 +22,7 @@ function as_dict() {
     export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -37,10 +37,10 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH;{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -52,7 +52,7 @@ function inherited() {
 export -f inherited;
 
 function as_list() {
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 }
 export -f as_list;
 
@@ -65,12 +65,12 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.

--- a/tests/reference_scripts/sh_win_env_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_win_env_launch/hab_config.sh
@@ -4,7 +4,7 @@ export PS1="[not_set/child] $PS1"
 # Setting global environment variables:
 unset UNSET_VARIABLE
 export TEST="case"
-export FMT_FOR_OS="a;b;c:$PATH;d"
+export FMT_FOR_OS="a:b;c:$PATH:d"
 unset ALIASED_GLOBAL_E
 export ALIASED_GLOBAL_B="Global B"
 export ALIASED_GLOBAL_C="Global C"
@@ -22,7 +22,7 @@ function as_dict() {
     export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -37,10 +37,10 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH;{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -52,7 +52,7 @@ function inherited() {
 export -f inherited;
 
 function as_list() {
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 }
 export -f as_list;
 
@@ -65,12 +65,12 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.

--- a/tests/reference_scripts/sh_win_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_win_launch/hab_config.sh
@@ -4,7 +4,7 @@ export PS1="[not_set/child] $PS1"
 # Setting global environment variables:
 unset UNSET_VARIABLE
 export TEST="case"
-export FMT_FOR_OS="a;b;c:$PATH;d"
+export FMT_FOR_OS="a:b;c:$PATH:d"
 unset ALIASED_GLOBAL_E
 export ALIASED_GLOBAL_B="Global B"
 export ALIASED_GLOBAL_C="Global C"
@@ -22,7 +22,7 @@ function as_dict() {
     export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -37,10 +37,10 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH;{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -52,7 +52,7 @@ function inherited() {
 export -f inherited;
 
 function as_list() {
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 }
 export -f as_list;
 
@@ -65,12 +65,12 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.

--- a/tests/reference_scripts/sh_win_launch_args/hab_config.sh
+++ b/tests/reference_scripts/sh_win_launch_args/hab_config.sh
@@ -4,7 +4,7 @@ export PS1="[not_set/child] $PS1"
 # Setting global environment variables:
 unset UNSET_VARIABLE
 export TEST="case"
-export FMT_FOR_OS="a;b;c:$PATH;d"
+export FMT_FOR_OS="a:b;c:$PATH:d"
 unset ALIASED_GLOBAL_E
 export ALIASED_GLOBAL_B="Global B"
 export ALIASED_GLOBAL_C="Global C"
@@ -22,7 +22,7 @@ function as_dict() {
     export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -37,10 +37,10 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH;{{ config_root }}/distros/aliased/2.0/test"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.
@@ -52,7 +52,7 @@ function inherited() {
 export -f inherited;
 
 function as_list() {
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 }
 export -f as_list;
 
@@ -65,12 +65,12 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 
     # Run alias command
-    python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";
+    python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
 
     # Restore the previous environment without alias specific hab variables by
     # removing variables hab added, then restore the original variable values.

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -8,7 +8,7 @@ def test_e_format():
     assert Formatter('sh').format('-{;}-') == '-:-'
     # Bash formatting is different on windows for env vars
     assert Formatter('shwin').format('-{PATH!e}-') == '-$PATH-'
-    assert Formatter('shwin').format('-{;}-') == '-;-'
+    assert Formatter('shwin').format('-{;}-') == '-:-'
 
     assert Formatter('ps').format('-{PATH!e}-') == '-$env:PATH-'
     assert Formatter('ps').format('-{;}-') == '-;-'


### PR DESCRIPTION
- Add function to convert a single windows file path to a cygwin compatible one
- Env var paths are converted to cygwin compatible paths and uses ':' for the pathsep to ensure proper conversion
- Check that we can include spaces in env var paths

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

This fixes an issue when using bash on windows and you want to inherit an environment variable from the system. The simple formatting used by the bash system of wrapping windows paths in double quotes doesn't work.

It was generating `export PATH="$PATH;c:\temp"`. This doesn't work, you need to use `:` as the separator and have to pass unix style paths in the .sh file. The simplest way to do this is `export PATH="$PATH;/c/temp"`.

This adds `utils.cygpath` to convert a windows path into a unix path. This doesn't use cygpath.exe as it made testing difficult and flakey. If you run tests in bash on widows it would convert the powershell and batch scripts to unix style. If you ran the tests in a command prompt, it would not have access to cygwin.exe. For what hab needs, it was simpler to roll our own method we can improve over time.