### PR TITLE
Support older Jinja2 installs required by some applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,10 @@ You can administratively default the execution policy to unrestricted for window
 * To use `hab activate` in bash or Powershell you need to use `.` or `source`. Powershell
 has the `.` operator so I would use that for both Powershell and bash.
 `. hab activate default`.
+* Jinja2 and MarkupSafe minimum requirements should be respected. This allows hab
+to work with Houdini 19.5 that ships with very dated versions of these packages.
+In practice this just means that we have to cast pathlib objects to strings before
+passing them to Jinja2.
 
 # Glosary
 

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -564,7 +564,9 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
         """
 
         environment = Environment(
-            loader=FileSystemLoader(TEMPLATES), trim_blocks=True, lstrip_blocks=True
+            loader=FileSystemLoader(str(TEMPLATES)),
+            trim_blocks=True,
+            lstrip_blocks=True,
         )
         template = environment.get_template(f"{template}{ext}")
         kwargs = dict(
@@ -624,7 +626,9 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
             str: The rendered script.
         """
         environment = Environment(
-            loader=FileSystemLoader(TEMPLATES), trim_blocks=True, lstrip_blocks=True
+            loader=FileSystemLoader(str(TEMPLATES)),
+            trim_blocks=True,
+            lstrip_blocks=True,
         )
         template = environment.get_template(f"{template}{ext}")
         kwargs = dict(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ anytree
 click>=7.1.2
 colorama
 future>=0.18.2
-Jinja2
+Jinja2>=2.10.1
+MarkupSafe>=0.23
 packaging>=20.0
 Pygments
 setuptools>=44.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,8 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    Jinja2
+    Jinja2>=2.10.1
+    MarkupSafe>=0.23
     Pygments
     anytree
     click>=7.1.2

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -103,7 +103,9 @@ def test_scripts(resolver, tmpdir, monkeypatch, config_root, reference_name):
         # Using Jinja for this because other python str formatting methods require
         # too much manipulation of the reference files.
         environment = Environment(
-            loader=FileSystemLoader(item.parent), trim_blocks=True, lstrip_blocks=True
+            loader=FileSystemLoader(str(item.parent)),
+            trim_blocks=True,
+            lstrip_blocks=True,
         )
         template = environment.get_template(item.name)
         # Note: jinja2' seems to be inconsistent with its trailing newlines depending


### PR DESCRIPTION
Jinja2 and MarkupSafe minimum requirements should be respected. This allows hab to work with Houdini 19.5 that ships with very dated versions of these packages. In practice this just means that we have to cast pathlib objects to strings before
passing them to Jinja2.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
