### PR TITLE
Cygpath is only required for the PATH variable when using cygwin

### DIFF
--- a/hab/templates/config.sh
+++ b/hab/templates/config.sh
@@ -4,7 +4,7 @@ export PS1="[{{ hab_cfg.uri }}] $PS1"
 # Setting global environment variables:
 {% for key, value in hab_cfg.environment.items() %}
 {% if value %}
-    {% set value = utils.Platform.collapse_paths(value, ext=ext) %}
+    {% set value = utils.Platform.collapse_paths(value, ext=ext, key=key) %}
     {% set value = formatter.format(value, key=key, value=value) %}
 export {{ key }}="{{ value }}"
 {% else %}
@@ -27,7 +27,7 @@ function {{ alias }}() {
     hab_bac_{{ alias_norm }}=`export -p`
     {% for k, v in alias_env.items() %}
     {% if v %}
-        {% set v = utils.Platform.collapse_paths(v, ext=ext) %}
+        {% set v = utils.Platform.collapse_paths(v, ext=ext, key=k) %}
         {% set v = formatter.format(v, key=key, value=v) %}
     export {{ k }}="{{ v }}"
     {% else %}

--- a/tests/distros/aliased/2.0/.hab.json
+++ b/tests/distros/aliased/2.0/.hab.json
@@ -17,7 +17,11 @@
                     "cmd": ["python", "{relative_root}/list_vars.py"],
                     "environment": {
                         "append": {
-                            "PATH": ["{PATH!e}", "{relative_root}/PATH/env/with  spaces"]
+                            "PATH": [
+                                "{PATH!e}",
+                                "{relative_root}/PATH/env/with  spaces",
+                                "/mnt/shared_resources/with spaces"
+                            ]
                         }
                     }
                 }
@@ -60,7 +64,11 @@
                     "cmd": ["python", "{relative_root}/list_vars.py"],
                     "environment": {
                         "append": {
-                            "PATH": ["{PATH!e}", "{relative_root}/PATH/env/with  spaces"]
+                            "PATH": [
+                                "{PATH!e}",
+                                "{relative_root}/PATH/env/with  spaces",
+                                "\\\\example\\shared_resources\\with spaces"
+                            ]
                         }
                     }
                 }

--- a/tests/reference_scripts/bat_activate/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_activate/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/bat_activate_launch/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_activate_launch/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/bat_env/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_env/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/bat_env_launch/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_env_launch/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/bat_launch/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_launch/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/bat_launch_args/aliases/inherited.bat
+++ b/tests/reference_scripts/bat_launch_args/aliases/inherited.bat
@@ -5,7 +5,7 @@ REM memory that can be called from the command prompt like in other shells.
 REM Set alias specific environment variables that only persist for while
 REM this script is running.
 SETLOCAL
-set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+set "PATH=%PATH%;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
 REM Run alias command
 python {{ config_root }}/distros/aliased/2.0/list_vars.py %*

--- a/tests/reference_scripts/ps1_activate/hab_config.ps1
+++ b/tests/reference_scripts/ps1_activate/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/ps1_activate_launch/hab_config.ps1
+++ b/tests/reference_scripts/ps1_activate_launch/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/ps1_env/hab_config.ps1
+++ b/tests/reference_scripts/ps1_env/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/ps1_env_launch/hab_config.ps1
+++ b/tests/reference_scripts/ps1_env_launch/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/ps1_launch/hab_config.ps1
+++ b/tests/reference_scripts/ps1_launch/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/ps1_launch_args/hab_config.ps1
+++ b/tests/reference_scripts/ps1_launch_args/hab_config.ps1
@@ -34,7 +34,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     $hab_bac_inherited = Get-ChildItem env:
-    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    $env:PATH="$env:PATH;{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces;//example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py $args

--- a/tests/reference_scripts/sh_linux_activate/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_activate/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces:/mnt/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_linux_activate_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_activate_launch/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces:/mnt/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_linux_env/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_env/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces:/mnt/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_linux_env_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_env_launch/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces:/mnt/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_linux_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_launch/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces:/mnt/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_linux_launch_args/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_launch_args/hab_config.sh
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces:/mnt/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root }}/distros/aliased/2.0/list_vars.py "$@";

--- a/tests/reference_scripts/sh_win_activate/hab_config.sh
+++ b/tests/reference_scripts/sh_win_activate/hab_config.sh
@@ -19,7 +19,7 @@ function as_dict() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_as_dict=`export -p`
-    export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
+    export ALIASED_LOCAL="{{ config_root_alias }}/distros/aliased/2.0/test"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces://example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -65,7 +65,7 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 

--- a/tests/reference_scripts/sh_win_activate_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_win_activate_launch/hab_config.sh
@@ -19,7 +19,7 @@ function as_dict() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_as_dict=`export -p`
-    export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
+    export ALIASED_LOCAL="{{ config_root_alias }}/distros/aliased/2.0/test"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces://example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -65,7 +65,7 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 

--- a/tests/reference_scripts/sh_win_env/hab_config.sh
+++ b/tests/reference_scripts/sh_win_env/hab_config.sh
@@ -19,7 +19,7 @@ function as_dict() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_as_dict=`export -p`
-    export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
+    export ALIASED_LOCAL="{{ config_root_alias }}/distros/aliased/2.0/test"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces://example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -65,7 +65,7 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 

--- a/tests/reference_scripts/sh_win_env_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_win_env_launch/hab_config.sh
@@ -19,7 +19,7 @@ function as_dict() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_as_dict=`export -p`
-    export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
+    export ALIASED_LOCAL="{{ config_root_alias }}/distros/aliased/2.0/test"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces://example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -65,7 +65,7 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 

--- a/tests/reference_scripts/sh_win_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_win_launch/hab_config.sh
@@ -19,7 +19,7 @@ function as_dict() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_as_dict=`export -p`
-    export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
+    export ALIASED_LOCAL="{{ config_root_alias }}/distros/aliased/2.0/test"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces://example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -65,7 +65,7 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 

--- a/tests/reference_scripts/sh_win_launch_args/hab_config.sh
+++ b/tests/reference_scripts/sh_win_launch_args/hab_config.sh
@@ -19,7 +19,7 @@ function as_dict() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_as_dict=`export -p`
-    export ALIASED_LOCAL="{{ config_root }}/distros/aliased/2.0/test"
+    export ALIASED_LOCAL="{{ config_root_alias }}/distros/aliased/2.0/test"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -37,7 +37,7 @@ function inherited() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_inherited=`export -p`
-    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces"
+    export PATH="$PATH:{{ config_root }}/distros/aliased/2.0/PATH/env/with  spaces://example/shared_resources/with spaces"
 
     # Run alias command
     python {{ config_root_alias }}/distros/aliased/2.0/list_vars.py "$@";
@@ -65,7 +65,7 @@ function global() {
     # Set alias specific environment variables. Backup the previous variable
     # value and export status, and add the hab managed variables
     hab_bac_global=`export -p`
-    export ALIASED_GLOBAL_A="Local A Prepend:Global A:Local A Append"
+    export ALIASED_GLOBAL_A="Local A Prepend;Global A;Local A Append"
     export ALIASED_GLOBAL_C="Local C Set"
     unset ALIASED_GLOBAL_D
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -449,6 +449,10 @@ def test_path_expansion(resolver, value, check):
 
 class TestPlatform:
     def test_collapse_paths(self):
+        # NOTE: The `ext=".sh", key="PATH"` checks are covering the special case
+        # that exists for PATH when using cygwin that doesn't apply to other
+        # environment variables. See `utils.WinPlatform.collapse_paths` for details.
+
         # Passing strings
         arg = "test case"
         assert utils.LinuxPlatform.collapse_paths(arg) == "test case"
@@ -456,38 +460,53 @@ class TestPlatform:
         assert utils.WinPlatform.collapse_paths(arg) == "test case"
         assert utils.WinPlatform.collapse_paths(arg, ext="") == "test case"
         assert utils.WinPlatform.collapse_paths(arg, ext=".sh") == "test case"
+        assert (
+            utils.WinPlatform.collapse_paths(arg, ext=".sh", key="PATH") == "test case"
+        )
 
         # Passing lists that are not paths
         arg = ["test", "case"]
         assert utils.LinuxPlatform.collapse_paths(arg) == "test:case"
         assert utils.OsxPlatform.collapse_paths(arg) == "test:case"
         assert utils.WinPlatform.collapse_paths(arg) == "test;case"
-        assert utils.WinPlatform.collapse_paths(arg, ext="") == "test:case"
-        assert utils.WinPlatform.collapse_paths(arg, ext=".sh") == "test:case"
+        assert utils.WinPlatform.collapse_paths(arg, ext="") == "test;case"
+        assert utils.WinPlatform.collapse_paths(arg, ext=".sh") == "test;case"
+        assert (
+            utils.WinPlatform.collapse_paths(arg, ext=".sh", key="PATH") == "test:case"
+        )
 
         # Passing lists that are windows paths
         arg = ["c:\\test", "C:\\case"]
         assert utils.LinuxPlatform.collapse_paths(arg) == "c:\\test:C:\\case"
         assert utils.OsxPlatform.collapse_paths(arg) == "c:\\test:C:\\case"
         assert utils.WinPlatform.collapse_paths(arg) == "c:\\test;C:\\case"
-        assert utils.WinPlatform.collapse_paths(arg, ext="") == "/c/test:/C/case"
-        assert utils.WinPlatform.collapse_paths(arg, ext=".sh") == "/c/test:/C/case"
+        assert utils.WinPlatform.collapse_paths(arg, ext="") == "c:\\test;C:\\case"
+        assert utils.WinPlatform.collapse_paths(arg, ext=".sh") == "c:\\test;C:\\case"
+        assert (
+            utils.WinPlatform.collapse_paths(arg, ext=".sh", key="PATH")
+            == "/c/test:/C/case"
+        )
 
         # Passing lists that are linux paths
         arg = ["/test", "/case"]
         assert utils.LinuxPlatform.collapse_paths(arg) == "/test:/case"
         assert utils.OsxPlatform.collapse_paths(arg) == "/test:/case"
         assert utils.WinPlatform.collapse_paths(arg) == "/test;/case"
-        assert utils.WinPlatform.collapse_paths(arg, ext="") == "/test:/case"
-        assert utils.WinPlatform.collapse_paths(arg, ext=".sh") == "/test:/case"
+        assert utils.WinPlatform.collapse_paths(arg, ext="") == "/test;/case"
+        assert utils.WinPlatform.collapse_paths(arg, ext=".sh") == "/test;/case"
+        assert (
+            utils.WinPlatform.collapse_paths(arg, ext=".sh", key="PATH")
+            == "/test:/case"
+        )
 
     def test_pathsep(self):
         assert utils.LinuxPlatform.pathsep() == ":"
         assert utils.OsxPlatform.pathsep() == ":"
         assert utils.WinPlatform.pathsep() == ";"
         # Ext is not ignored for windows
-        assert utils.WinPlatform.pathsep(ext="") == ":"
-        assert utils.WinPlatform.pathsep(ext=".sh") == ":"
+        assert utils.WinPlatform.pathsep(ext="") == ";"
+        assert utils.WinPlatform.pathsep(ext=".sh") == ";"
+        assert utils.WinPlatform.pathsep(ext=".sh", key="PATH") == ":"
 
 
 def test_cygpath():


### PR DESCRIPTION
Addresses #41 by only calling cygpath when processing the `PATH` env var.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

After some more testing I've figured out that we only need to convert to cygpath and use `:` when modifying the `PATH` env variable, not any of the other environment variables. https://cygwin.com/cygwin-ug-net/setup-env.html.

If you run this in cygwin
```bash
export AB="\\\\example\a\path;c:\temp"
export AB="$AB;c:\other;\\\\server\share"
py -c "import os;print(os.environ['AB'])"
```
It outputs `\\example\a\path;c:\temp;c:\other;\\server\share` which is expected.

If you try to do the same for `PATH`, it does not work as expected
```bash
export PATH="$PATH;c:\other;\\\\server\share"
py -c "import os;from pprint import pprint;pprint(os.environ['PATH'].split(';'))"
```
Outputs:
```
[...,
 'C:\\Program Files\\Git\\usr\\bin\\core_perl',
 'c',
 'C:\\other',
 '\\server\\share']
```

` 'c',` is incorrect and could cause issues. If you reset your bash and run this instead, it works as expected:
```bash
export PATH="$PATH:/c/other;//server/share"
py -c "import os;from pprint import pprint;pprint(os.environ['PATH'].split(';'))"
```
```
[...,
 'C:\\Program Files\\Git\\usr\\bin\\core_perl',
 'C:\\other',
 '\\server\\share']
 ```

The previous cygpath commit was applying that fix to all environment variables, but it turns out we only need to apply it to `PATH`. This MR changes hab to only apply cygpath changes for the `PATH` environment variable.