### PR TITLE
Support defining global env vars in a config and using complex aliases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ environment variable so you can simply run the `hab` command.
 pip3 install hab
 ```
 
-If you want to make use of (json5)[https://pypi.org/project/pyjson5/] formatting
+If you want to make use of [json5](https://pypi.org/project/pyjson5/) formatting
 when creating the various json files that drives hab, you should use the optional
 json5 dependency. This lets you add comments and allows for trailing commas.
 

--- a/hab/parsers/flat_config.py
+++ b/hab/parsers/flat_config.py
@@ -64,6 +64,11 @@ class FlatConfig(Config):
     def _finalize_values(self):
         """Post processing done after `_collect_values` is run."""
 
+        # `_process_version` needs the global environment variables populated
+        # so populating per-alias env var's properly inherit the global variables.
+        # This call ensures that `self.frozen_data["environment"]` is populated.
+        self.environment
+
         # Process version aliases, merging global env vars.
         platform_aliases = {}
         self.frozen_data["aliases"] = platform_aliases

--- a/tests/configs/app/app_aliased_mod.json
+++ b/tests/configs/app/app_aliased_mod.json
@@ -5,5 +5,10 @@
     "distros": [
         "aliased",
         "aliased_mod"
-    ]
+    ],
+    "environment": {
+        "set" : {
+            "CONFIG_DEFINED": "config_variable"
+        }
+    }
 }

--- a/tests/distros/aliased/2.0/list_vars.py
+++ b/tests/distros/aliased/2.0/list_vars.py
@@ -22,6 +22,7 @@ print_var("ALIASED_GLOBAL_C")
 print_var("ALIASED_GLOBAL_D")
 print_var("ALIASED_GLOBAL_E")
 print_var("ALIASED_LOCAL")
+print_var("CONFIG_DEFINED")
 print("")
 
 print(' PATH env var '.center(80, '-'))

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -49,9 +49,7 @@ def test_freeze(monkeypatch, config_root, platform, pathsep):
     monkeypatch.setattr(os, 'pathsep', pathsep)
     site = Site([config_root / "site_main.json"])
     resolver = Resolver(site=site)
-
     cfg_root = utils.path_forward_slash(config_root)
-    cfg = resolver.resolve("not_set/distros")
 
     # Add a platform_path_maps mapping to convert the current hab checkout path
     # to a generic know path on the other platform for uniform testing.
@@ -66,13 +64,14 @@ def test_freeze(monkeypatch, config_root, platform, pathsep):
     else:
         mappings['local-hab'][site.platform] = PurePosixPath(cfg_root)
 
+    # Resolve the URI for frozen testing
+    cfg = resolver.resolve("not_set/distros")
+
     # Ensure consistent testing across platforms. cfg has the current os's
     # file paths instead of what is stored in frozen.json
     cfg.frozen_data["aliases"]["linux"]["dcc"] = "TEST_DIR_NAME//the_dcc"
     cfg.frozen_data["aliases"]["windows"]["dcc"] = "TEST_DIR_NAME\\the_dcc.exe"
 
-    # Force the lazily loaded `cfg.frozen_data["environment"]` value to be loaded
-    cfg.environment
     # Ensure the HAB_URI environment variable is defined on the FlatConfig object
     # When checking the return from `cfg.freeze()` below HAB_URI is removed to
     # simplify the output json data.

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -719,6 +719,13 @@ def test_alias_mods_global(resolver):
     assert cfg.environment['ALIASED_GLOBAL_E'] is None
     assert cfg.environment['ALIASED_GLOBAL_F'] == ['Global F']
     assert cfg.environment['ALIASED_MOD_GLOBAL_A'] == ['Global Mod A']
+    # This global env var was defined by the config json file.
+    # Ensure that it did not get lost at some point in the process.
+    assert cfg.environment['CONFIG_DEFINED'] == ['config_variable']
+    # This variable is always added by hab automatically
+    assert cfg.environment['HAB_URI'] == ['app/aliased/mod']
+    # Ensure no extra env vars were defined
+    assert len(cfg.environment) == 9
 
     # Check cmd is expected
     assert alias["cmd"][0] == "python"


### PR DESCRIPTION
To replicate the bug, add this environment section to `tests/configs/app/app_aliased_mod.json`
```json
    "environment": {
        "set" : {
            "CONFIG_DEFINED": "config_variable"
        }
    }
```

Then when running this hab command, an `KeyError: 'environment'` error is raised.
```bash
$ hab -v dump app/aliased/mod
INFO:hab.cli:Context: app/aliased/mod
INFO:hab.solvers:Resolving requirements: {'aliased': <Requirement('aliased')>, 'aliased_mod': <Requirement('aliased_mod')>}
INFO:hab.solvers:Attempt 1 at resolving requirements
Hab encountered an error:
Traceback (most recent call last):
  File "C:\Program Files\Python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Program Files\Python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\blur\dev\hab_\hab\__main__.py", line 14, in <module>
    sys.exit(hab.cli.cli(prog_name="python -m hab"))
  File "C:\blur\dev\hab_\hab\cli.py", line 496, in cli
    return _cli(*args, **kwargs)
  File "C:\Program Files\Python39\lib\site-packages\click\core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "C:\Program Files\Python39\lib\site-packages\click\core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "C:\Program Files\Python39\lib\site-packages\click\core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\Program Files\Python39\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Program Files\Python39\lib\site-packages\click\core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "C:\Program Files\Python39\lib\site-packages\click\decorators.py", line 38, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "C:\blur\dev\hab_\hab\cli.py", line 415, in dump
    ret = settings.resolver.resolve(uri)
  File "C:\blur\dev\hab_\hab\__init__.py", line 270, in resolve
    return context.reduced(self, uri=uri)
  File "C:\blur\dev\hab_\hab\parsers\hab_base.py", line 489, in reduced
    return FlatConfig(self, resolver, uri=uri)
  File "C:\blur\dev\hab_\hab\parsers\flat_config.py", line 28, in __init__
    self._finalize_values()
  File "C:\blur\dev\hab_\hab\parsers\flat_config.py", line 71, in _finalize_values
    for platform, alias, data in self._process_version(
  File "C:\blur\dev\hab_\hab\parsers\flat_config.py", line 132, in _process_version
    global_env = self.frozen_data["environment"].get(host_platform, {})
KeyError: 'environment'
```


## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [x] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

This MR forces the population of `frozen_data["environment"]` at the correct time so it can be when processing complex aliases.