### PR TITLE
Issue #45

### DIFF
--- a/hab/cli.py
+++ b/hab/cli.py
@@ -51,7 +51,7 @@ class UriArgument(click.Argument):
         if value == "-":
             uri_check = ctx.obj.resolver.user_prefs().uri_check()
 
-            # Let's create some messages for later use             
+            # Let's create some messages for later use
             warning = (f"{click.style('Invalid ''URI'' preference: ', fg='red')}"
                 f"The saved uri {click.style(uri_check.uri_value, fg='green')} "
                 f"expired and needs re-saved.")
@@ -379,7 +379,7 @@ def env(settings, uri, launch):
 )
 def dump(settings, uri, env, env_config, report_type, flat, verbosity, format_type):
     """Resolves and prints the requested setup."""
-    
+
     # Convert uri argument to handle if a uri was not provided/loaded
     uri_error = None
     if isinstance(uri, click.UsageError):
@@ -429,7 +429,7 @@ def dump(settings, uri, env, env_config, report_type, flat, verbosity, format_ty
             ret = settings.resolver.resolve(uri)
         else:
             ret = settings.resolver.closest_config(uri)
-            
+
         # This is a seperate set of if/elif/else statements than from above.  I became confused while reading
         # so decided to add this reminder.
         if format_type == "freeze":
@@ -444,7 +444,7 @@ def dump(settings, uri, env, env_config, report_type, flat, verbosity, format_ty
             ret = ret.dump(
                 environment=env, environment_config=env_config, verbosity=verbosity
             )
-        
+
         click.echo(ret)
 
 

--- a/hab/user_prefs.py
+++ b/hab/user_prefs.py
@@ -1,8 +1,8 @@
 import datetime
 import json
 import logging
-from pathlib import Path
 from collections import namedtuple
+from pathlib import Path
 
 from . import utils
 
@@ -132,7 +132,7 @@ class UserPrefs(dict):
         # Declaring a namedtuple to send over to cli.py
         # A namedtuple provides more user friendly access to it's stored data
         # than a standard dict.
-        URI_Check = namedtuple("URI_Check", 
+        URI_Check = namedtuple("URI_Check",
                                (field for field in uri_check_dict.keys()))
         return URI_Check(**uri_check_dict)
 


### PR DESCRIPTION
Adding functionality to address the saved instances when the
.hab_user_prefs.json timestamp expires.  Currently Hab will just error
out.

I've addessed this in both user_prefs.py and cli.py.  In user_prefs.py
I've replaced the "uri_reason" method with a method named "uri_check".
This method passes data onto the cli.py in the form of a namedtuple.
I then moved the job of naming the "reason" over into the cli.py.

In the cli.py, I then am taking the data from uri_check to determine
if the user_prefs timestamp has expire, then I provide the user with the
option to resave the prefs with an updated timestamp then continue using
Hab.  If the user declines to resave, Hab will quit with a
click.UsageError message.