### PR TITLE
Add set-uri command

### DIFF
--- a/hab/cli.py
+++ b/hab/cli.py
@@ -336,6 +336,17 @@ def _cli(
     logging.basicConfig(level=level)
 
 
+# set uri command
+@_cli.command(cls=UriHelpClass)
+@click.argument("uri", cls=UriArgument)
+@click.pass_obj
+def set_uri(settings, uri):
+    settings.log_context(uri)
+    if uri:
+        click.echo(f"\nSetting default URI to: {Fore.LIGHTBLUE_EX}{uri}{Fore.RESET}\n")
+        settings.resolver.user_prefs().uri = uri
+
+
 # env command
 @_cli.command(cls=UriHelpClass)
 @click.argument("uri", cls=UriArgument)


### PR DESCRIPTION
Add a command called `set-uri` that allows the uer to estblish a default URI by storing it in `.hab_user_prefs.json`.  If no file exists calling `set-uri` will create it.  If the file already exists then the command will update the file with the new URI.

Example: `hab set-uri app/usd/py/39`

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [ ] I formatted my changes with [black](https://github.com/psf/black)
- [ ] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [ ] I have added documentation regarding my changes where necessary
- [ ] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
