### PR TITLE
Establishing required versions specific packages

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
-black
+black==22.12.0
 covdefaults
 coverage
-flake8
-flake8-bugbear
-pep8-naming
+flake8==5.0.4
+flake8-bugbear==22.12.6
+pep8-naming==0.13.3
 pytest
 tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,12 +53,12 @@ exclude = tests
 
 [options.extras_require]
 dev =
-    black
+    black==22.12.0
     covdefaults
     coverage
-    flake8
-    flake8-bugbear
-    pep8-naming
+    flake8==5.0.4
+    flake8-bugbear==22.12.6
+    pep8-naming==0.13.3
     pytest
     tox
 json5 =

--- a/tox.ini
+++ b/tox.ini
@@ -37,15 +37,15 @@ commands =
 [testenv:black]
 basepython = python3
 deps =
-    black==23.1.0
+    black==22.12.0
 commands =
     black . --check
 
 [testenv:flake8]
 basepython = python3
 deps =
-    flake8
+    flake8==5.0.4
     flake8-bugbear==22.12.6
-    pep8-naming
+    pep8-naming==0.13.3
 commands =
     flake8 .


### PR DESCRIPTION
We discovered that some required formatting packages were out of sync
with the intended versions.  I'm establishing specific version requirements
in the setup.cfg for optional dev installs.