### PR TITLE
Fix bug saving user prefs and add hab developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,56 @@ set "HAB_PATHS=c:\path\to\site_b.json;/c/path/to/site_a.json"
 $env:HAB_PATHS="c:\path\to\site_b.json;c:\path\to\site_a.json"
 ```
 
+# Hab Developer Quickstart
+
+Hab has some code quality automated checks and extensive unit testing setup. When
+contributing, you should make sure your changes match the flake8 rules and follow
+the configured [black](https://github.com/psf/black) formatting.
+
+## pre-commit hooks
+
+It's recommended that you install the configured
+[pre-commit](https://pre-commit.com/#3-install-the-git-hook-scripts) hooks.
+These test for and fix black and flake8 issues as well as other file checks.
+
+Use pip to install pre-commit if it's not already installed.
+```
+pip3 install pre-commit
+```
+Install the hab configuration of pre-commit hooks to enable them when using git.
+Run this from the root of your git checkout.
+```
+pre-commit install
+```
+
+From this point forward when you commit changes using git, it will pre-validate
+and fix most code quality issues. Those changes are not staged so you can inspect
+the changes it makes.
+
+## tox
+
+We use tox to do all unit tests using pytest and also run black and flake8 code
+quality checks. You should use tox before you push your code changes to ensure
+that your tests will pass when running on github.
+
+
+Install tox if its not already installed:
+```
+pip3 install tox
+```
+
+To run all tests. Make sure to run tox from the root of your git checkout:
+```
+tox
+```
+
+Examples of running specific tests:
+- `tox -e py37-json`  Run just the py37-json test
+- `tox -e py39-json5`  Run just the py39-json5 test
+- `tox -e begin,py37-json,end`  Show code coverage report for just this test
+- `tox -e flake8`  Run the flake8 tests
+- `tox -e begin,py37-json,end -- -vv`  Enables verbose mode for pytest. Any text after `--` is passed as cli arguments passed to pytest
+
 # Overview
 
 ## URI

--- a/hab/__init__.py
+++ b/hab/__init__.py
@@ -1,13 +1,4 @@
-__all__ = [
-    "__version__",
-    "Config",
-    "DistroVersion",
-    "HabBase",
-    "NotSet",
-    "Resolver",
-    "Site",
-    "Solver",
-]
+__all__ = ["__version__", "NotSet", "Resolver", "Site"]
 
 from .utils import NotSet
 

--- a/hab/cli.py
+++ b/hab/cli.py
@@ -30,9 +30,9 @@ class UriArgument(click.Argument):
         When using a user pref, a message is written to the error stream to
         ensure the user can see what uri was resolved. It is written to the error
         stream so it doesn't interfere with capturing output to a file(json).
-    - If the timestamp on the user_prefs.json is lapse, the user will be prompted
-        to address the out of date URI by entering a new path or using the already
-        saved path.
+    - If the timestamp on the .hab_user_prefs.json is lapse, the user will be
+        prompted to address the out of date URI by entering a new path or using
+        the already saved path.
 
     This also handles saving the provided uri to user prefs if enabled by
     `SharedSettings.enable_user_prefs_save`. This is only respected if an uri is
@@ -76,8 +76,12 @@ class UriArgument(click.Argument):
             # This will indicate that no user_pref.json was saved
             # and the user will be required to enter a uri path.
             if uri_check.uri is None:
-                return self.__uri_prompt()
-            # Check if the saved user_prefs.json has an expire timestamp
+                value = self.__uri_prompt()
+                # Saving a new .hab_user_prefs.json
+                ctx.obj.resolver.user_prefs().uri = value
+                click.echo("Saving hab user prefs", err=True)
+                return value
+            # Check if the saved .hab_user_prefs.json has an expire timestamp
             elif uri_check.timedout:
                 logger.info(
                     f"{Fore.RED}Invalid 'URI' preference: {Fore.RESET}"
@@ -87,9 +91,9 @@ class UriArgument(click.Argument):
                 # The uri is expired so lets ask the user for a new uri
                 value = self.__uri_prompt(uri_check.uri)
                 if value:
-                    # Saving a new user_prefs.json
+                    # Saving an updated .hab_user_prefs.json
                     ctx.obj.resolver.user_prefs().uri = value
-                    click.echo("Saving user_prefs.json", err=True)
+                    click.echo("Saving hab user prefs", err=True)
                     return value
                 else:
                     if self.required:
@@ -98,7 +102,7 @@ class UriArgument(click.Argument):
             else:
                 click.echo(
                     f"Using {Fore.LIGHTBLUE_EX}{uri_check.uri}{Fore.RESET} "
-                    "from user_prefs.json",
+                    "from hab user prefs",
                     err=True,
                 )
                 # Don't allow users to re-save the user prefs value when using

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -572,3 +572,28 @@ def test_natrual_sort():
     result = utils.natural_sort(nodes, key=lambda i: i.name)
     check = [n.name for n in result]
     assert check == ["test1", "test2", "Test3", "test10"]
+
+
+def test_star_import():
+    """Check if a import was removed from __init__.py but did not get removed
+    from `__all__`.
+
+    Flake8 doesn't seem to capture F822 when run on `__init__.py`. Manually
+    attempt a `from hab import *` import to ensure that all of the items listed
+    in `__all__` are actually importable.
+    """
+
+    # https://stackoverflow.com/a/43059528
+    import importlib
+
+    # get a handle on the module
+    mdl = importlib.import_module("hab")
+    # is there an __all__?  if so respect it
+    names = mdl.__dict__["__all__"]
+
+    # Simulate `from hab import *` which can only be done at the module level.
+    for k in names:
+        # NOTE: If an exception is raised here, you need to remove the attribute
+        # name from __all__ or make sure to import the missing object.
+        # `AttributeError: module 'hab' has no attribute 'DistroVersion'`
+        getattr(mdl, k)


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [x] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

1. Add documentation to help a new hab developer configure their testing environment.
2. Fix error if using `from hab import *`. Recent updates removed the imports of objects that were still being added to `__all__` that caused an error. We use `__all__` to prevent needing to add `# noqa: F822` to each "unused" import exposed on `hab`. Adds a test to check for this issue.
3. If you try to use `hab dump -` and haven't already stored a URI as a user preference, it would not save the new user preference. You had to call `hab set-uri ...` at least once for hab to remember your previous URI. This is now fixed.