### PR TITLE
Add plugin system controlled by site files

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ encountered object is used and any duplicates are ignored. Here are some example
 that follow that rule and links to details:
 
 * **Aliases:** [Multiple app versions](#multiple-app-versions)
+* **Entry Points:** [Hab Entry Points](#hab-entry-points)
 * **Site:** [Site](#site)
 
 `config_paths` and `distro_paths` have [more complex rules](#common-settings).
@@ -403,6 +404,36 @@ Note the order of left/middle/right in the test_paths variable. Also, for
 `platform_path_maps`, `host` is defined in all 3 site files, but only the first
 site file with it defined is used. The other path maps are picked up from the
 site file they are defined in.
+
+#### Hab Entry Points
+
+The site file can be used to replace some hab functionality with custom plugins.
+These are defined in site files with the "entry_points" dictionary.
+
+[Example](tests/site/site_entry_point_a.json) site json entry_point config.
+```json5
+{
+    "prepend": {
+        "entry_points": {
+            // Group
+            "cli": {
+               // Name: Object Reference
+               "gui": "hab_test_entry_points:gui"
+            }
+        }
+    }
+}
+```
+See the [Entry points specification data model](https://packaging.python.org/en/latest/specifications/entry-points/#data-model)
+for details on each item.
+
+| Feature | Description | Multiple values |
+|---|---|---|
+| cli | Used by the hab cli to add extra commands | All unique names are used. |
+| launch_cli | Used as the default `cls` by `hab.parsers.Config.launch()` to launch aliases from inside of python. This should be a subclass of subprocess.Popen. | Only the first is used, the rest are discarded. |
+
+The name of each entry point is used to de-duplicate results from multiple site json files.
+This follows the general rule defined in [duplicate definitions](#duplicate-definitions).
 
 ### Python version
 
@@ -566,7 +597,7 @@ A given config needs two pieces of information defined, its name and context. Th
 context is a list of its parents names. When joined together they will build a URI.
 
 Example project_a_thug_animation.json:
-```json
+```json5
 {
     "name": "Animation",
     "context": ["project_a", "Thug"],

--- a/hab/launcher.py
+++ b/hab/launcher.py
@@ -1,0 +1,47 @@
+import subprocess
+import sys
+
+from . import utils
+
+try:
+    CREATE_NO_WINDOW = subprocess.CREATE_NO_WINDOW
+except AttributeError:
+    # This constant comes from the WindowsAPI, but is not
+    # defined in subprocess until python 3.7
+    CREATE_NO_WINDOW = 0x08000000
+
+
+class Launcher(subprocess.Popen):
+    """Runs cmd using subprocess.Popen enabling stdout/err/in redirection.
+    On windows prevents showing of command prompts when running with pythonw.
+
+    Args:
+        args (list or string): The command to be run by subprocess.
+        **kwargs: Any keyword arguments are passed to subprocess.Popen. The
+            standard defaults for **kwargs are modified to enable stdout/stderr
+            capture to a single merged stdout stream. Also adds platform specific
+            workarounds for stdin. Changes bufsize to 1 if possible to allow for
+            per-line updating of output.
+    """
+
+    def __init__(self, args, **kwargs):
+        # Change the defaults for subprocess.Popen to make it easier to capture
+        # output from the launched subprocess.
+        kwargs.setdefault("stdout", subprocess.PIPE)
+        kwargs.setdefault("stderr", subprocess.STDOUT)
+        kwargs.setdefault("universal_newlines", True)
+        # In python 3.8+ changing bufsize when universal_newlines is False
+        # causes a warning message.
+        if kwargs["universal_newlines"] or kwargs.get("text") is True:
+            kwargs.setdefault("bufsize", 1)
+
+        if utils.Platform.name() == "windows" and "pythonw" in sys.executable.lower():
+            # Windows 7 has an issue with making subprocesses
+            # if the stdin handle is None, so pass the PIPE
+            kwargs.setdefault("stdin", subprocess.PIPE)
+
+            # If this is a pythonw process, because there is no current window
+            # for stdout, any subprocesses will try to create a new window
+            kwargs.setdefault("creationflags", CREATE_NO_WINDOW)
+
+        super().__init__(args, **kwargs)

--- a/hab/parsers/config.py
+++ b/hab/parsers/config.py
@@ -1,4 +1,4 @@
-from .. import NotSet
+from .. import NotSet, utils
 from .hab_base import HabBase
 from .meta import hab_property
 
@@ -11,6 +11,14 @@ class Config(HabBase):
     def __init__(self, *args, **kwargs):
         self._alias_mods = NotSet
         super().__init__(*args, **kwargs)
+
+    @hab_property(process_order=120)
+    def aliases(self):
+        """Dict of the names and commands that need created to launch desired
+        applications."""
+        ret = self.frozen_data.get("aliases", {}).get(utils.Platform.name(), {})
+        # Only return aliases if they are valid for the current verbosity
+        return {k: v for k, v in ret.items() if self.check_min_verbosity(v)}
 
     # Note: 'alias_mods' needs to be processed before 'environment'
     @hab_property(verbosity=3, process_order=50)

--- a/hab/parsers/flat_config.py
+++ b/hab/parsers/flat_config.py
@@ -129,14 +129,6 @@ class FlatConfig(Config):
                 data["environment"] = merged_env[platform]
                 yield platform, alias_name, data
 
-    @hab_property(process_order=120)
-    def aliases(self):
-        """List of the names and commands that need created to launch desired
-        applications."""
-        ret = self.frozen_data.get("aliases", {}).get(utils.Platform.name(), {})
-        # Only return aliases if they are valid for the current verbosity
-        return {k: v for k, v in ret.items() if self.check_min_verbosity(v)}
-
     # Note: 'alias_mods' needs to be processed before 'environment'
     @hab_property(verbosity=None, process_order=50)
     def alias_mods(self):

--- a/hab/parsers/unfrozen_config.py
+++ b/hab/parsers/unfrozen_config.py
@@ -1,7 +1,7 @@
 import logging
 from copy import deepcopy
 
-from .. import NotSet, utils
+from .. import NotSet
 from .config import Config
 from .meta import hab_property
 
@@ -25,11 +25,11 @@ class UnfrozenConfig(Config):
         # Frozen versions are already a list of strings
         return sorted(value)
 
-    @hab_property()
-    def aliases(self):
-        """List of the names and commands that need created to launch desired
-        applications."""
-        return self.frozen_data.get("aliases", {}).get(utils.Platform.name(), [])
+    # Note: 'alias_mods' needs to be processed before 'environment'
+    @hab_property(verbosity=None, process_order=50)
+    def alias_mods(self):
+        """Returns NotSet. Any alias_mods have already been baked into aliases."""
+        return NotSet
 
     @hab_property(verbosity=2)
     def inherits(self):

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -390,6 +390,7 @@ class BasePlatform(ABC):
     the subclass to Platform. `hab.utils.Platform = hab.utils.WinPlatform`
     """
 
+    _default_ext = ".sh"
     _name = None
     _sep = ":"
 
@@ -413,6 +414,11 @@ class BasePlatform(ABC):
         if isinstance(paths, str):
             return paths
         return cls.pathsep(ext=ext).join([str(p) for p in paths])
+
+    @classmethod
+    def default_ext(cls):
+        """Returns the default file extension used on this platform."""
+        return cls._default_ext
 
     @classmethod
     def expand_paths(cls, paths):
@@ -487,6 +493,7 @@ class BasePlatform(ABC):
 
 
 class WinPlatform(BasePlatform):
+    _default_ext = ".bat"
     _name = "windows"
     _sep = ";"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ anytree
 click>=7.1.2
 colorama
 future>=0.18.2
+importlib-metadata
 Jinja2>=2.10.1
 MarkupSafe>=0.23
 packaging>=20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     click>=7.1.2
     colorama
     future>=0.18.2
+    importlib-metadata
     packaging>=20.0
     setuptools-scm[toml]>=4
 python_requires = >=3.6

--- a/tests/hab_test_entry_points.py
+++ b/tests/hab_test_entry_points.py
@@ -1,0 +1,9 @@
+def gui():
+    """Used to test entry point resolution. Raises an exception for ease of testing."""
+    raise NotImplementedError("hab_test_entry_points.gui called successfully")
+
+
+def gui_alt():
+    """Used to test entry point resolution site modification. Raises an exception
+    for ease of testing."""
+    raise NotImplementedError("hab_test_entry_points.gui_alt called successfully")

--- a/tests/site/site_entry_point_a.json
+++ b/tests/site/site_entry_point_a.json
@@ -3,6 +3,9 @@
         "entry_points": {
             "cli": {
                 "test-gui": "hab_test_entry_points:gui"
+            },
+            "launch_cls": {
+                "subprocess": "subprocess:Popen"
             }
         }
     },

--- a/tests/site/site_entry_point_a.json
+++ b/tests/site/site_entry_point_a.json
@@ -1,0 +1,12 @@
+{
+    "append": {
+        "entry_points": {
+            "cli": {
+                "test-gui": "hab_test_entry_points:gui"
+            }
+        }
+    },
+    "set": {
+        "prefs_default": "--prefs"
+    }
+}

--- a/tests/site/site_entry_point_b.json
+++ b/tests/site/site_entry_point_b.json
@@ -1,0 +1,9 @@
+{
+    "append": {
+        "entry_points": {
+            "cli": {
+                "test-gui": "hab_test_entry_points:gui_alt"
+            }
+        }
+    }
+}

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -94,6 +94,10 @@ def test_freeze(monkeypatch, config_root, platform, pathsep):
     ret = cfg.freeze()
     assert "versions" not in ret
 
+    # Frozen configs don't need to encode alias_mods, the modifications are
+    # already baked into aliases
+    assert "alias_mods" not in ret
+
 
 def test_unfreeze(config_root, resolver):
     check_file = config_root / "frozen.json"
@@ -130,6 +134,10 @@ def test_unfreeze(config_root, resolver):
     assert "dcc" in cfg.aliases
     assert cfg.fullpath == "not_set/distros"
     assert cfg.inherits is False
+
+    # Frozen configs don't need to encode alias_mods, the modifications are
+    # already baked into aliases
+    assert cfg.alias_mods is NotSet
 
 
 def test_decode_freeze(config_root, resolver):

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,0 +1,170 @@
+import functools
+import os
+import re
+import site
+import subprocess
+import sys
+
+import pytest
+
+from hab import Resolver, Site, utils
+from hab.errors import HabError
+
+
+class Topen(subprocess.Popen):
+    """A custom subclass of Popen."""
+
+
+def missing_annotations_hack(function):
+    """Decorator that works around a missing annotations module in python 3.6.
+
+    Allows for calling subprocess calls in python 3.6 that would normally fail
+    with a `SyntaxError: future feature annotations is not defined` exception.
+
+    Works by temporarily removing the `_virtualenv.pth` file in the venv's
+    site-packages.
+
+    TODO: Figure out a better method until we can drop CentOS requirement.
+    """
+
+    @functools.wraps(function)
+    def new_function(*args, **kwargs):
+        if sys.version_info.minor != 6:
+            return function(*args, **kwargs)
+
+        site_packages = site.getsitepackages()
+        for path in site_packages:
+            pth = os.path.join(path, "_virtualenv.pth")
+            if os.path.exists(pth):
+                os.rename(pth, f"{pth}.bak")
+        try:
+            ret = function(*args, **kwargs)
+        finally:
+            for path in site_packages:
+                pth = os.path.join(path, "_virtualenv.pth.bak")
+                if os.path.exists(pth):
+                    os.rename(pth, pth[:-3])
+        return ret
+
+    return new_function
+
+
+def test_launch(resolver):
+    """Check the Config.launch method."""
+    cfg = resolver.resolve("app/aliased/mod")
+    proc = cfg.launch("global", args=None, blocking=True)
+
+    # Enabling mod_std sends all exception text to stdout
+    assert proc.output_stderr is None
+    check = [
+        " Env Vars: ".center(80, "-"),
+        "ALIASED_GLOBAL_A: ['Local Mod A', 'Local A Prepend', 'Global A', 'Local A Append']",
+        "ALIASED_GLOBAL_B: ['Global B']",
+        "ALIASED_GLOBAL_C: ['Local C Set']",
+        "ALIASED_GLOBAL_D: <UNSET>",
+        "ALIASED_GLOBAL_E: <UNSET>",
+        "ALIASED_LOCAL: <UNSET>",
+        "CONFIG_DEFINED: ['config_variable']",
+        "",
+        " PATH env var ".center(80, "-"),
+    ]
+
+    assert "\n".join(check) in proc.output_stdout
+
+
+@missing_annotations_hack
+def test_launch_str(resolver):
+    cfg = resolver.resolve("app/aliased/mod")
+
+    # Check that args are passed to the subprocess
+    # Check that if "cmd" is a str, it is converted to a list and extended with args
+    args = ["-c", 'print("success")']
+    proc = cfg.launch("as_str", args=args, blocking=True)
+    assert proc.output_stdout.strip() == "success"
+
+    # Check that passing env is respected
+    env = dict(os.environ)
+    var_name = "TEST_ADDED_VARIABLE"
+    var_value = "Test variable"
+    assert var_name not in env
+    env[var_name] = var_value
+
+    # Check that Popen kwargs can be passed through launch, including env.
+    args = [
+        "-c",
+        'import os;assert os.environ["{}"] != "{}"'.format(var_name, var_value),
+    ]
+    proc = cfg.launch("as_str", args=args, blocking=True, env=env)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="only applies on windows")
+def test_pythonw(monkeypatch, resolver):
+    """Check that sys.stdin is set if using pythonw."""
+    cfg = resolver.resolve("app/aliased/mod")
+
+    # If not using pythonw.exe proc.stdin is not routed to PIPE
+    proc = cfg.launch("global", args=None, blocking=True)
+    assert proc.stdin is None
+
+    # If using pythonw.exe, proc.stdin is routed to PIPE
+    pyw = re.sub("python.exe", "pythonw.exe", sys.executable, flags=re.I)
+    monkeypatch.setattr(sys, "executable", pyw)
+    proc = cfg.launch("global", args=None, blocking=True)
+    assert proc.stdin is not None
+
+
+def test_invalid_alias(resolver):
+    cfg = resolver.resolve("app/aliased/mod")
+    with pytest.raises(HabError, match='"not-a-alias" is not a valid alias name'):
+        cfg.launch("not-a-alias")
+
+    # Remove the "cmd" value to test an invalid configuration
+    alias = cfg.frozen_data["aliases"][utils.Platform.name()]["global"]
+    del alias["cmd"]
+
+    with pytest.raises(HabError, match='Alias "global" does not have "cmd" defined'):
+        cfg.launch("global")
+
+
+def test_cls_no_entry_point(resolver):
+    """Check that if no entry point is defined, `hab.launcher.Launcher` is
+    used to launch the alias.
+    """
+    entry_points = resolver.site.entry_points_for_group("launch_cls")
+    assert len(entry_points) == 0
+
+    cfg = resolver.resolve("app/aliased/mod")
+    proc = cfg.launch("global", blocking=True)
+
+    from hab.launcher import Launcher
+
+    assert type(proc) is Launcher
+
+    # Check that specifying cls, overrides default
+    proc = cfg.launch("global", blocking=True, cls=Topen)
+    assert type(proc) is Topen
+
+
+def test_cls_entry_point(config_root):
+    """Check that if an entry point is defined, it is used unless overridden."""
+    site = Site(
+        [config_root / "site/site_entry_point_a.json", config_root / "site_main.json"]
+    )
+    entry_points = site.entry_points_for_group("launch_cls")
+    assert len(entry_points) == 1
+    # Test that the `test-gui` cli entry point is handled correctly
+    ep = entry_points[0]
+    assert ep.name == "subprocess"
+    assert ep.group == "launch_cls"
+    assert ep.value == "subprocess:Popen"
+
+    resolver = Resolver(site=site)
+    cfg = resolver.resolve("app/aliased/mod")
+
+    # Check that entry_point site config is respected
+    proc = cfg.launch("global", blocking=True)
+    assert type(proc) is subprocess.Popen
+
+    # Check that specifying cls, overrides site config
+    proc = cfg.launch("global", blocking=True, cls=Topen)
+    assert type(proc) is Topen

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -220,6 +220,7 @@ def test_metaclass():
     assert set(Config._properties.keys()) == set(
         [
             "alias_mods",
+            "aliases",
             "distros",
             "environment",
             "environment_config",


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
Add entry point system for the cli allowing other plugins to add themselves to the hab cli. This is configured by site files not if a pip package is installed. These changes are required to enable blurstudio/hab-gui#1 and help with blurstudio/hab-gui#2.