### PR TITLE
Add default for entry_points_for_group and handle edge case in URI's

### DIFF
--- a/hab/resolver.py
+++ b/hab/resolver.py
@@ -90,6 +90,10 @@ class Resolver(object):
         """
         if not path.startswith(HabBase.separator):
             path = "".join((HabBase.separator, path))
+        # Anytree<2.9.0 had a bug when resolving URI's that end in a slash like
+        # `app/` would cause a IndexError. This ensure that older versions work
+        path = path.rstrip("/")
+
         if default:
             node_names = path.split(HabBase.separator)
             current = self.configs["default"]

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -93,6 +93,10 @@ def test_config(resolver):
             "default/Sc11",
             "More specific default secondary not returned",
         ),
+        # Leading/trailing separators
+        ("/app", "app", "Leading slash not ignored"),
+        ("app/", "app", "Trailing slash not sanitized correctly"),
+        ("app/case/", "app", "Trailing slash not sanitized correctly"),
     ),
 )
 def test_closest_config(resolver, path, result, reason):

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -467,6 +467,18 @@ class TestEntryPoints:
         entry_points = site.entry_points_for_group("cli")
         assert len(entry_points) == 0
 
+    def test_default(self, config_root):
+        """Test a site not defining any entry points for cli."""
+        site = Site([config_root / "site_main.json"])
+        entry_points = site.entry_points_for_group("cli", default={"test": "case:func"})
+        assert len(entry_points) == 1
+
+        # Test that the `test-gui` cli entry point is handled correctly
+        ep = entry_points[0]
+        assert ep.name == "test"
+        assert ep.group == "cli"
+        assert ep.value == "case:func"
+
     @pytest.mark.parametrize(
         "site_files,import_name,fname",
         (


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

- If you passed the URI `app/` with anytree<2.9.0 installed it would raise an `IndexError: list index out of range` error. This sanitizes that by removing trailing slashes.
- Adds a way to easily specify default entry points that get cast to `importlib_metadata.EntryPoint` when using `Site.entry_points_for_group`.