### PR TITLE
Support requirement markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,25 +947,32 @@ using os specific configurations.
 
 ### Defining Distros
 
-The `distos` key in distro and config definitions is used to define the distro version
+The `distos` key in distro and config definitions are used to define the distro version
 requirements. When a config is processed the distro requirements are evaluated recursively
 to include the requirements of the latest DistroVersion matching the specifier.
-This uses the python packaging module to resolve version specifiers so you can use the
-same configuration syntax you would use in a pip requirements file.
+This uses the python [packaging module](https://packaging.pypa.io/en/stable/requirements.html)
+to resolve version specifiers so you can use the same configuration syntax you
+would use in a pip requirements file.
 
-```json
+```json5
     "distros": [
         "maya2020",
         "maya2022",
         "houdini18.5",
         "hsite",
         "animBot<=1.4",
-        "studiolibrary==2.5.7.post1"
+        "studiolibrary==2.5.7.post1",
+        // Use markers to only include 3ds max if hab is currently running on
+        // windows. It can't be run on linux.
+        "3dsmax2019;platform_system=='Windows'"
     ]
-
 ```
 
 The resolved versions matching the requested distros are shown in the `versions` property.
+
+It also supports [markers](https://packaging.pypa.io/en/stable/markers.html). Hab
+should support all of the [officially supported markers](https://peps.python.org/pep-0508/),
+but the most common marker likely to be used with hab is `platform_system`.
 
 ### Platform specific code
 

--- a/hab/solvers.py
+++ b/hab/solvers.py
@@ -100,6 +100,19 @@ class Solver(object):
 
         for req in reqs:
             name = req.name
+
+            marker = req.marker
+            if marker and not marker.evaluate():
+                # If a marker is specified and its not valid for the current
+                # system, skip this requirement.
+                # https://packaging.pypa.io/en/stable/markers.html
+                msg = f"Requirement ignored due to marker: {req}"
+                if name in self.forced:
+                    logger.critical(f"Forced {msg}")  # pragma: no cover
+                else:
+                    logger.warning(f"{msg}")
+                continue
+
             if name in self.forced:
                 if name in reported:
                     # Once we have processed this requirement, there is no need to


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
It also supports [markers](https://packaging.pypa.io/en/stable/markers.html). Hab
should support all of the [officially supported markers](https://peps.python.org/pep-0508/),
but the most common marker likely to be used with hab is `platform_system`.