### PR TITLE
Correctly map requirements and user-pref settings

### DIFF
--- a/hab/cli.py
+++ b/hab/cli.py
@@ -398,6 +398,7 @@ _verbose_errors = False
 @click.option(
     "-r",
     "--requirement",
+    "forced_requirements",
     callback=SharedSettings.set_ctx_instance,
     multiple=True,
     help="Forces this distro requirement ignoring normally resolved requirements. Using "
@@ -414,29 +415,20 @@ _verbose_errors = False
 )
 @click.option(
     "--prefs/--no-prefs",
+    "enable_user_prefs",
     callback=SharedSettings.set_ctx_instance,
     default=None,
     help="If you don't pass a URI, allow looking it up from user prefs.",
 )
 @click.option(
     "--save-prefs/--no-save-prefs",
+    "enable_user_prefs_save",
     callback=SharedSettings.set_ctx_instance,
     default=None,
     help="Update the uri stored in prefs if the uri is provided.",
 )
 @click.pass_context
-def _cli(
-    ctx,
-    site_paths,
-    verbosity,
-    script_dir,
-    script_ext,
-    prereleases,
-    requirement,
-    dump_scripts,
-    prefs,
-    save_prefs,
-):
+def _cli(ctx, **kargs):
     # Note: Using the `set_ctx_instance` callback on the options prevents
     # the need to process anything inside of this function.
     pass


### PR DESCRIPTION
`hab -r` was broken by `Re-work how the SharedSetting instance is created on ctx.obj` as well as the pref saving flags.
This correctly names the variables so they are respected by SharedSettings.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [ ] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
