### PR TITLE
Config.launch now supports defining `launch_cls` entry_points per alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ for details on each item.
 | Feature | Description | Multiple values |
 |---|---|---|
 | cli | Used by the hab cli to add extra commands | All unique names are used. |
-| launch_cli | Used as the default `cls` by `hab.parsers.Config.launch()` to launch aliases from inside of python. This should be a subclass of subprocess.Popen. | Only the first is used, the rest are discarded. |
+| launch_cls | Used as the default `cls` by `hab.parsers.Config.launch()` to launch aliases from inside of python. This should be a subclass of subprocess.Popen. A [complex alias](#complex-aliases) may override this per alias. Defaults to [`hab.launcher.Launcher`](hab/launcher.py). [Example](tests/site/site_entry_point_a.json) | Only the first is used, the rest are discarded. |
 
 The name of each entry point is used to de-duplicate results from multiple site json files.
 This follows the general rule defined in [duplicate definitions](#duplicate-definitions).
@@ -767,12 +767,19 @@ active hab config, but in this case prepends an additional value on
 `ALIASED_GLOBAL_A` will be set to `Global A`. However while you are using the
 alias `as_dict`, the variable will be set to `Local A Prepend;Global A`.
 
-Complex Aliases have two keys:
+Complex Aliases supports several keys:
 1. `cmd` is the command to run. When list or str defined aliases are resolved,
 their value is stored under this key.
 2. `environment`: A set of env var configuration options. For details on this
 format, see [Defining Environments](#defining-environments). This is not
 os_specific due to aliases already being defined per-platform.
+3. `launch_cls`: If defined this entry_point is used instead of the Site defined
+or default class specifically for launching this alias.
+See [houdini](tests/distros/houdini19.5/19.5.493/.hab.json) for an example.
+
+Note: Plugins may add support for their own keys.
+[Hab-gui](https://github.com/blurstudio/hab-gui#icons-and-labels)
+adds icon and label for example.
 
 **Use Case:** You want to add a custom AssetResolver to USD for Maya, Houdini,
 and standalone usdview. To get this to work, you need to compile your plugin

--- a/hab/site.py
+++ b/hab/site.py
@@ -83,7 +83,7 @@ class Site(UserDict):
         ret = "\n".join(ret)
         return utils.dump_title("Dump of Site", f"{site_ret}\n{ret}", color=color)
 
-    def entry_points_for_group(self, group, default=None):
+    def entry_points_for_group(self, group, default=None, entry_points=None):
         """Returns a list of importlib_metadata.EntryPoint objects enabled by
         this site config. To import and resolve the defined object call `ep.load()`.
 
@@ -93,13 +93,17 @@ class Site(UserDict):
                 the entry points defined by this dictionary. This is the contents
                 of the entry_points group, not the entire entry_points dict. For
                 example: `{"gui": "hab_gui.cli:gui"}`
+            entry_points (dict, optional): Use this dictionary instead of the one
+                defined on this Site object.
         """
         # Delay this import to when required. It's faster than pkg_resources but
         # no need to pay the import price for it if you are not using it.
         from importlib_metadata import EntryPoint
 
         ret = []
-        entry_points = self.get("entry_points", {})
+        # Use the site defined entry_points if an override dict wasn't provided
+        if entry_points is None:
+            entry_points = self.get("entry_points", {})
 
         # Get the entry point definitions, falling back to default if provided
         if group in entry_points:

--- a/tests/distros/houdini19.5/19.5.493/.hab.json
+++ b/tests/distros/houdini19.5/19.5.493/.hab.json
@@ -32,24 +32,29 @@
         ],
         "windows": [
             [
-                "houdini",
-                "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdini.exe"
+                "houdini",{
+                    "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdini.exe",
+                    "launch_cls": {"subprocess": "subprocess:Popen"}
+                }
             ],
             [
                 "houdini19.5", {
                     "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdini.exe",
-                    "min_verbosity": {"global": 1}
+                    "min_verbosity": {"global": 1},
+                    "launch_cls": {"subprocess": "subprocess:Popen"}
                 }
             ],
             [
                 "houdinicore", {
-                    "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdinicore.exe"
+                    "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdinicore.exe",
+                    "launch_cls": {"subprocess": "subprocess:Popen"}
                 }
             ],
             [
                 "houdinicore19.5", {
                     "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdinicore.exe",
-                    "min_verbosity": {"global": 1}
+                    "min_verbosity": {"global": 1},
+                    "launch_cls": {"subprocess": "subprocess:Popen"}
                 }
             ],
             [


### PR DESCRIPTION
If launching houdini using hab-gui using `habw.exe gui launch`, houdini would not be able to print. The stdout/stderror objects will not accept write's.

This seems to be happening because Launcher uses `subprocess.PIPE` to capture stdout/stderr. Switching to the normal `subprocess.Popen` class instead fixes houdini.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

This PR makes it so we can define a per-alias launcher class.

Example .hab.json for houdini:
```json5
{
    "name": "houdini19.5",
    "aliases": {
        "windows": [
            [
                "houdinicore", {
                    "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.716\\bin\\houdinicore.exe",
                    "icon": "{relative_root}/.img/houdini.ico",
                    "label": "Houdini Core",
                    // Launcher captures stdout/error and this breaks printing
                    // when launching houdini's gui. Just use the standard class
                    "launch_cls": {"subprocess": "subprocess:Popen"},
                }
            ]
        ]
    }
}
```