### PR TITLE
A config with no distros respects forced requirements

### DIFF
--- a/hab/parsers/flat_config.py
+++ b/hab/parsers/flat_config.py
@@ -197,8 +197,14 @@ class FlatConfig(Config):
 
     @hab_property(verbosity=1)
     def versions(self):
-        if self.distros is NotSet:
-            return []
+        distros = self.distros
+        if distros is NotSet:
+            if self.resolver.forced_requirements:
+                distros = {}
+            else:
+                return []
+        if distros == []:
+            distros = {}
 
         # Lazily load the contents of versions the first time it's called
         if "versions" not in self.frozen_data:
@@ -207,7 +213,7 @@ class FlatConfig(Config):
                 self._alias_mods = {}
             self.frozen_data["versions"] = versions
 
-            reqs = self.resolver.resolve_requirements(self.distros)
+            reqs = self.resolver.resolve_requirements(distros)
             for req in reqs.values():
                 version = self.resolver.find_distro(req)
                 versions.append(version)

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ url = https://github.com/blurstudio/hab
 author = Blur Studio
 author_email = opensource@blur.com
 license = LGPL-3.0
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console


### PR DESCRIPTION
Addresses #35

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

Fixes this bug and also modernizes the license_file setting in setup.cfg

Testing:

1. Set `HAB_PATH` to your `tests\site_main.json`
2. Use the URI `not_set/no_distros`. This is a config that doesn't inherit and doesn't define distros.
3. Run `hab -r aliased dump not_set/no_distros -v`. You will now see aliased listed in the versions section.
```
WARNING:hab.solvers:Forced Requirement: aliased
Dump of FlatConfig('not_set/no_distros')
----------------------------------------------------------
name:  no_distros
uri:  not_set/no_distros
aliases:  as_dict inherited as_list as_str global
versions:  aliased==2.0
----------------------------------------------------------
```
4. If you remove `-r aliased` from the command you won't see any versions. This is the correct behavior.
```
Dump of FlatConfig('not_set/no_distros')
-------------------------------------------------
name:  no_distros
uri:  not_set/no_distros
versions:
-------------------------------------------------
```