### PR TITLE
When using `Config.launch` expand environment variables

### DIFF
--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -664,7 +664,8 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
         """
         ext = utils.Platform.default_ext()
         if formatter is None:
-            formatter = Formatter(ext)
+            # Make sure to expand environment variables when formatting.
+            formatter = Formatter(ext, expand=True)
 
         def _apply(data):
             for key, value in data.items():


### PR DESCRIPTION
## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

When using subprocess to launch an alias that extends an existing env var by using `{PATH!e}`, it would add `%PATH%`, `$PATH`, etc instead of including the actual value of PATH. This is incorrect and breaks applications. See [tests/distros/aliased/2.0/.hab.json](https://github.com/blurstudio/hab/blob/main/tests/distros/aliased/2.0/.hab.json) for an example.