### PR TITLE
Convert entry_points to dotted notation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ These are defined in site files with the "entry_points" dictionary.
     "prepend": {
         "entry_points": {
             // Group
-            "cli": {
+            "hab.cli": {
                // Name: Object Reference
                "gui": "hab_test_entry_points:gui"
             }
@@ -437,11 +437,14 @@ for details on each item.
 
 | [Group][tt-group] | Description | [\*\*kwargs][tt-kwargs] | [Return][tt-return] | [Multiple][tt-multi] |
 |---|---|---|---|---|
-| cli | Used by the hab cli to add extra commands. This is expected to be a `click.command` or `click.group` decorated function. |  |  | [All][tt-multi-all] |
-| launch_cls | Used as the default `cls` by `hab.parsers.Config.launch()` to launch aliases from inside of python. This should be a subclass of subprocess.Popen. A [complex alias](#complex-aliases) may override this per alias. Defaults to [`hab.launcher.Launcher`](hab/launcher.py). [Example](tests/site/site_entry_point_a.json) |  |  | [First][tt-multi-first] |
+| hab.cli | Used by the hab cli to add extra commands. This is expected to be a `click.command` or `click.group` decorated function. |  |  | [All][tt-multi-all] |
+| hab.launch_cls | Used as the default `cls` by `hab.parsers.Config.launch()` to launch aliases from inside of python. This should be a subclass of subprocess.Popen. A [complex alias](#complex-aliases) may override this per alias. Defaults to [`hab.launcher.Launcher`](hab/launcher.py). [Example](tests/site/site_entry_point_a.json) |  |  | [First][tt-multi-first] |
 
 The name of each entry point is used to de-duplicate results from multiple site json files.
 This follows the general rule defined in [duplicate definitions](#duplicate-definitions).
+
+Entry_point names should start with `hab.` and use `.` between each following word
+following the group specification on https://packaging.python.org/en/latest/specifications/entry-points/#data-model.
 
 ### Python version
 
@@ -781,7 +784,7 @@ their value is stored under this key.
 2. `environment`: A set of env var configuration options. For details on this
 format, see [Defining Environments](#defining-environments). This is not
 os_specific due to aliases already being defined per-platform.
-3. `launch_cls`: If defined this entry_point is used instead of the Site defined
+3. `hab.launch_cls`: If defined this entry_point is used instead of the Site defined
 or default class specifically for launching this alias.
 See [houdini](tests/distros/houdini19.5/19.5.493/.hab.json) for an example.
 

--- a/README.md
+++ b/README.md
@@ -427,10 +427,18 @@ These are defined in site files with the "entry_points" dictionary.
 See the [Entry points specification data model](https://packaging.python.org/en/latest/specifications/entry-points/#data-model)
 for details on each item.
 
-| Feature | Description | Multiple values |
-|---|---|---|
-| cli | Used by the hab cli to add extra commands | All unique names are used. |
-| launch_cls | Used as the default `cls` by `hab.parsers.Config.launch()` to launch aliases from inside of python. This should be a subclass of subprocess.Popen. A [complex alias](#complex-aliases) may override this per alias. Defaults to [`hab.launcher.Launcher`](hab/launcher.py). [Example](tests/site/site_entry_point_a.json) | Only the first is used, the rest are discarded. |
+<!-- Tooltips used by the table -->
+[tt-group]: ## "The hab feature this entry_point is being used for."
+[tt-kwargs]: ## "Any keyword arguments that are passed when called."
+[tt-return]: ## "The entry_point can return a value and how it will be used. If not documented, then any returned value is ignored."
+[tt-multi]: ## "How having multiple entry_points for this group is handled."
+[tt-multi-all]: ## "All uniquely named entry point names for this group are run."
+[tt-multi-first]: ## "Only the first entry_point for this group is used, the rest are discarded."
+
+| [Group][tt-group] | Description | [\*\*kwargs][tt-kwargs] | [Return][tt-return] | [Multiple][tt-multi] |
+|---|---|---|---|---|
+| cli | Used by the hab cli to add extra commands. This is expected to be a `click.command` or `click.group` decorated function. |  |  | [All][tt-multi-all] |
+| launch_cls | Used as the default `cls` by `hab.parsers.Config.launch()` to launch aliases from inside of python. This should be a subclass of subprocess.Popen. A [complex alias](#complex-aliases) may override this per alias. Defaults to [`hab.launcher.Launcher`](hab/launcher.py). [Example](tests/site/site_entry_point_a.json) |  |  | [First][tt-multi-first] |
 
 The name of each entry point is used to de-duplicate results from multiple site json files.
 This follows the general rule defined in [duplicate definitions](#duplicate-definitions).

--- a/hab/cli.py
+++ b/hab/cli.py
@@ -296,7 +296,7 @@ class SiteCommandLoader(click.Group):
     additional `click.Command` objects to the hab cli.
 
     For example if you add this to your site json file:
-    `{"append": {"entry_points": {"cli": {"gui": "hab_gui.cli:gui"}}}}`
+    `{"append": {"entry_points": {"hab.cli": {"gui": "hab_gui.cli:gui"}}}}`
 
     The "gui" key in the innermost dict is used for site resolution so another
     site json file can replace a upper level definition. As a general rule, the
@@ -305,7 +305,7 @@ class SiteCommandLoader(click.Group):
     "hab_gui.cli:gui" defines what code to execute. For details on defining this,
     see value for `importlib-metadata.EntryPoints`. In practice this results in
     `from  hab_gui.cli import gui`.
-    For the `cli` entry points, its expected that the linked function(`gui`)
+    For the `hab.cli` entry points, its expected that the linked function(`gui`)
     is a `click.Command` object.
     """
 
@@ -317,7 +317,7 @@ class SiteCommandLoader(click.Group):
             self._ep_cache = []
 
         # And populate the cache
-        for ep in site.entry_points_for_group("cli"):
+        for ep in site.entry_points_for_group("hab.cli"):
             func = ep.load()
             self._ep_cache.append((ep, func))
 

--- a/hab/parsers/config.py
+++ b/hab/parsers/config.py
@@ -58,7 +58,7 @@ class Config(HabBase):
                 `output_stdout` and `output_stderr` properties added to proc.
             cls (class, optional): A `subprocess.Popen` compatible class is
                 initialized and used to run the alias. If not passed, then the
-                site entry_point `launch_cls` is used if defined. Otherwise the
+                site entry_point `hab.launch_cls` is used if defined. Otherwise the
                 `hab.launcher.Launcher` class is used.
             **kwargs: Any keyword arguments are passed to subprocess.Popen. If on
                 windows and using pythonw, prevents showing a command prompt.
@@ -74,15 +74,15 @@ class Config(HabBase):
         # Get the subprocess.Popen like class to use to launch the alias
         if cls is None:
             # Use the entry_point if defined on the alias
-            alias_cls = alias.get("launch_cls")
+            alias_cls = alias.get("hab.launch_cls")
             if alias_cls:
-                alias_cls = {"launch_cls": alias_cls}
+                alias_cls = {"hab.launch_cls": alias_cls}
                 eps = self.resolver.site.entry_points_for_group(
-                    "launch_cls", entry_points=alias_cls
+                    "hab.launch_cls", entry_points=alias_cls
                 )
             else:
                 # Otherwise use the global definition from Site
-                eps = self.resolver.site.entry_points_for_group("launch_cls")
+                eps = self.resolver.site.entry_points_for_group("hab.launch_cls")
 
             if eps:
                 cls = eps[0].load()

--- a/tests/distros/houdini19.5/19.5.493/.hab.json
+++ b/tests/distros/houdini19.5/19.5.493/.hab.json
@@ -34,27 +34,27 @@
             [
                 "houdini",{
                     "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdini.exe",
-                    "launch_cls": {"subprocess": "subprocess:Popen"}
+                    "hab.launch_cls": {"subprocess": "subprocess:Popen"}
                 }
             ],
             [
                 "houdini19.5", {
                     "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdini.exe",
                     "min_verbosity": {"global": 1},
-                    "launch_cls": {"subprocess": "subprocess:Popen"}
+                    "hab.launch_cls": {"subprocess": "subprocess:Popen"}
                 }
             ],
             [
                 "houdinicore", {
                     "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdinicore.exe",
-                    "launch_cls": {"subprocess": "subprocess:Popen"}
+                    "hab.launch_cls": {"subprocess": "subprocess:Popen"}
                 }
             ],
             [
                 "houdinicore19.5", {
                     "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdinicore.exe",
                     "min_verbosity": {"global": 1},
-                    "launch_cls": {"subprocess": "subprocess:Popen"}
+                    "hab.launch_cls": {"subprocess": "subprocess:Popen"}
                 }
             ],
             [

--- a/tests/site/site_entry_point_a.json
+++ b/tests/site/site_entry_point_a.json
@@ -1,10 +1,10 @@
 {
     "append": {
         "entry_points": {
-            "cli": {
+            "hab.cli": {
                 "test-gui": "hab_test_entry_points:gui"
             },
-            "launch_cls": {
+            "hab.launch_cls": {
                 "subprocess": "subprocess:Popen"
             }
         }

--- a/tests/site/site_entry_point_b.json
+++ b/tests/site/site_entry_point_b.json
@@ -1,7 +1,7 @@
 {
     "append": {
         "entry_points": {
-            "cli": {
+            "hab.cli": {
                 "test-gui": "hab_test_entry_points:gui_alt"
             }
         }

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -130,7 +130,7 @@ def test_cls_no_entry_point(resolver):
     """Check that if no entry point is defined, `hab.launcher.Launcher` is
     used to launch the alias.
     """
-    entry_points = resolver.site.entry_points_for_group("launch_cls")
+    entry_points = resolver.site.entry_points_for_group("hab.launch_cls")
     assert len(entry_points) == 0
 
     cfg = resolver.resolve("app/aliased/mod")
@@ -150,12 +150,12 @@ def test_cls_entry_point(config_root):
     site = Site(
         [config_root / "site/site_entry_point_a.json", config_root / "site_main.json"]
     )
-    entry_points = site.entry_points_for_group("launch_cls")
+    entry_points = site.entry_points_for_group("hab.launch_cls")
     assert len(entry_points) == 1
-    # Test that the `test-gui` cli entry point is handled correctly
+    # Test that the `test-gui` `hab.cli` entry point is handled correctly
     ep = entry_points[0]
     assert ep.name == "subprocess"
-    assert ep.group == "launch_cls"
+    assert ep.group == "hab.launch_cls"
     assert ep.value == "subprocess:Popen"
 
     resolver = Resolver(site=site)
@@ -186,9 +186,9 @@ def test_alias_entry_point(config_root):
     proc = cfg.launch("global", blocking=True)
     assert type(proc).__name__ == "Popen"
 
-    # Check that if the complex alias specifies launch_cls, it is used instead
+    # Check that if the complex alias specifies hab.launch_cls, it is used instead
     # of the site defined or default class.
     alias = cfg.frozen_data["aliases"][utils.Platform.name()]["global"]
-    alias["launch_cls"] = {"subprocess": "tests.test_launch:Topen"}
+    alias["hab.launch_cls"] = {"subprocess": "tests.test_launch:Topen"}
     proc = cfg.launch("global", blocking=True)
     assert type(proc).__name__ == "Topen"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -173,7 +173,7 @@ def test_scripts(resolver, tmpdir, monkeypatch, config_root, reference_name):
 
 @pytest.mark.skip(reason="Find a way to test complex alias evaluation in pytest")
 def test_complex_alias_bat(tmpdir, config_root, resolver):
-    """This test is a placeholder for a future that can actually call hab's cli
+    """This test is a placeholder for a future that can actually call hab's `hab.cli`
     and its aliases to check that they function correctly in Batch.
 
     This example text shows that using "hab env" can set an environment variable,
@@ -210,7 +210,7 @@ def test_complex_alias_bat(tmpdir, config_root, resolver):
 
 @pytest.mark.skip(reason="Find a way to test complex alias evaluation in pytest")
 def test_complex_alias_ps1(tmpdir, config_root, resolver):
-    """This test is a placeholder for a future that can actually call hab's cli
+    """This test is a placeholder for a future that can actually call hab's `hab.cli`
     and its aliases to check that they function correctly in PowerShell.
 
     This example text shows that using "hab env" can set an environment variable,
@@ -247,7 +247,7 @@ def test_complex_alias_ps1(tmpdir, config_root, resolver):
 
 @pytest.mark.skip(reason="Find a way to test complex alias evaluation in pytest")
 def test_complex_alias_sh(tmpdir, config_root, resolver):
-    """This test is a placeholder for a future that can actually call hab's cli
+    """This test is a placeholder for a future that can actually call hab's `hab.cli`
     and its aliases to check that they function correctly in Bash.
 
     This example text shows that using "hab env" can set an environment variable,

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -462,21 +462,23 @@ class TestPlatformPathMapDict:
 
 class TestEntryPoints:
     def test_empty_site(self, config_root):
-        """Test a site not defining any entry points for cli."""
+        """Test a site not defining any entry points for `hab.cli`."""
         site = Site([config_root / "site_main.json"])
-        entry_points = site.entry_points_for_group("cli")
+        entry_points = site.entry_points_for_group("hab.cli")
         assert len(entry_points) == 0
 
     def test_default(self, config_root):
-        """Test a site not defining any entry points for cli."""
+        """Test a site not defining any entry points for `hab.cli`."""
         site = Site([config_root / "site_main.json"])
-        entry_points = site.entry_points_for_group("cli", default={"test": "case:func"})
+        entry_points = site.entry_points_for_group(
+            "hab.cli", default={"test": "case:func"}
+        )
         assert len(entry_points) == 1
 
-        # Test that the `test-gui` cli entry point is handled correctly
+        # Test that the `test-gui` `hab.cli` entry point is handled correctly
         ep = entry_points[0]
         assert ep.name == "test"
-        assert ep.group == "cli"
+        assert ep.group == "hab.cli"
         assert ep.value == "case:func"
 
     @pytest.mark.parametrize(
@@ -496,15 +498,15 @@ class TestEntryPoints:
         ),
     )
     def test_site_cli(self, config_root, site_files, import_name, fname):
-        """Test a site defining an entry point for cli, possibly multiple times."""
+        """Test a site defining an entry point for `hab.cli`, possibly multiple times."""
         site = Site([config_root / f for f in site_files])
-        entry_points = site.entry_points_for_group("cli")
+        entry_points = site.entry_points_for_group("hab.cli")
         assert len(entry_points) == 1
 
-        # Test that the `test-gui` cli entry point is handled correctly
+        # Test that the `test-gui` `hab.cli` entry point is handled correctly
         ep = entry_points[0]
         assert ep.name == "test-gui"
-        assert ep.group == "cli"
+        assert ep.group == "hab.cli"
         assert ep.value == f"{import_name}:{fname}"
 
         # Load the module's function


### PR DESCRIPTION
Convert the entry point's _ separator to . to be inline with the group spec of https://packaging.python.org/en/latest/specifications/entry-points/#data-model. The [hab-gui](https://github.com/blurstudio/hab-gui/pull/14) pull request is part of this change.

I don't like making this kind of re-factor of a released feature but I think we should be using the same naming convention for entry_point groups in case we ever wanted to use the same group names for traditional entry_points.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
