### PR TITLE
Add several entry points to hab

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ for details on each item.
 |---|---|---|---|---|
 | hab.cli | Used by the hab cli to add extra commands. This is expected to be a `click.command` or `click.group` decorated function. |  |  | [All][tt-multi-all] |
 | hab.launch_cls | Used as the default `cls` by `hab.parsers.Config.launch()` to launch aliases from inside of python. This should be a subclass of subprocess.Popen. A [complex alias](#complex-aliases) may override this per alias. Defaults to [`hab.launcher.Launcher`](hab/launcher.py). [Example](tests/site/site_entry_point_a.json) |  |  | [First][tt-multi-first] |
+| hab.uri.validate | Used to validate and modify a URI. If the URI is invalid, this should raise an exception. If the URI should be modified, then return the modified URI as a string. | `resolver`, `uri` | Updated URI as string or None. | [All][tt-multi-all] |
 
 The name of each entry point is used to de-duplicate results from multiple site json files.
 This follows the general rule defined in [duplicate definitions](#duplicate-definitions).

--- a/README.md
+++ b/README.md
@@ -357,6 +357,15 @@ rules to keep in mind.
 on the outside of the the right site file's paths.
 3. For `platform_path_maps`, only the first key is kept and any duplicates
 are discarded.
+4. The entry_point `hab.site.add_paths` is processed separately after `HAB_PATH`
+or `--site` paths are processed, so:
+   * Each path added is treated as left most when merging into the final configuration.
+   * The entry_point `hab.site.add_paths` will be ignored for dynamically added paths.
+   * This can be used to include site files from inside of pip packages. For
+   example a host installed pip package may be installed in the system python,
+   or as a pip editable installation.
+   * Duplicate paths added dynamically are discarded keeping the first
+   encountered(right most).
 
 See [Defining Environments](#defining-environments) for how to structure the json
 to prepend, append, set, unset values.
@@ -441,6 +450,8 @@ for details on each item.
 | hab.cfg.reduce.env | Used to make any modifications to a config after the global env is resolved but before aliases are resolved. | `cfg` |  | [All][tt-multi-all] |
 | hab.cfg.reduce.finalize | Used to make any modifications to a config after aliases are resolved and just before the the config finishes reducing. | `cfg` |  | [All][tt-multi-all] |
 | hab.launch_cls | Used as the default `cls` by `hab.parsers.Config.launch()` to launch aliases from inside of python. This should be a subclass of subprocess.Popen. A [complex alias](#complex-aliases) may override this per alias. Defaults to [`hab.launcher.Launcher`](hab/launcher.py). [Example](tests/site/site_entry_point_a.json) |  |  | [First][tt-multi-first] |
+| hab.site.add_paths | Dynamically prepends extra [site configuration files](#site) to the current configuration. This entry_point is ignored for any configs added using this entry_point. | `site` | A `list` of `pathlib.Path` for existing site .json files. | [All][tt-multi-all] |
+| hab.site.finalize | Used to modify site configuration files just before the site is fully initialized. | `site` |  | [All][tt-multi-all] |
 | hab.uri.validate | Used to validate and modify a URI. If the URI is invalid, this should raise an exception. If the URI should be modified, then return the modified URI as a string. | `resolver`, `uri` | Updated URI as string or None. | [All][tt-multi-all] |
 
 The name of each entry point is used to de-duplicate results from multiple site json files.

--- a/README.md
+++ b/README.md
@@ -438,6 +438,8 @@ for details on each item.
 | [Group][tt-group] | Description | [\*\*kwargs][tt-kwargs] | [Return][tt-return] | [Multiple][tt-multi] |
 |---|---|---|---|---|
 | hab.cli | Used by the hab cli to add extra commands. This is expected to be a `click.command` or `click.group` decorated function. |  |  | [All][tt-multi-all] |
+| hab.cfg.reduce.env | Used to make any modifications to a config after the global env is resolved but before aliases are resolved. | `cfg` |  | [All][tt-multi-all] |
+| hab.cfg.reduce.finalize | Used to make any modifications to a config after aliases are resolved and just before the the config finishes reducing. | `cfg` |  | [All][tt-multi-all] |
 | hab.launch_cls | Used as the default `cls` by `hab.parsers.Config.launch()` to launch aliases from inside of python. This should be a subclass of subprocess.Popen. A [complex alias](#complex-aliases) may override this per alias. Defaults to [`hab.launcher.Launcher`](hab/launcher.py). [Example](tests/site/site_entry_point_a.json) |  |  | [First][tt-multi-first] |
 | hab.uri.validate | Used to validate and modify a URI. If the URI is invalid, this should raise an exception. If the URI should be modified, then return the modified URI as a string. | `resolver`, `uri` | Updated URI as string or None. | [All][tt-multi-all] |
 

--- a/hab/parsers/flat_config.py
+++ b/hab/parsers/flat_config.py
@@ -35,6 +35,9 @@ class FlatConfig(Config):
         # This call ensures that `self.frozen_data["environment"]` is populated.
         self.environment
 
+        # Run any configured entry_points before aliases are calculated
+        self.resolver.site.run_entry_points_for_group("hab.cfg.reduce.env", cfg=self)
+
         # Process version aliases, merging global env vars.
         platform_aliases = {}
         self.frozen_data["aliases"] = platform_aliases
@@ -43,6 +46,11 @@ class FlatConfig(Config):
                 version, existing=platform_aliases
             ):
                 platform_aliases.setdefault(platform, {})[alias] = data
+
+        # Run any configured entry_points before finishing
+        self.resolver.site.run_entry_points_for_group(
+            "hab.cfg.reduce.finalize", cfg=self
+        )
 
     def _process_version(self, version, existing=None):
         """Generator that yields each finalized alias definition dictionary

--- a/hab/site.py
+++ b/hab/site.py
@@ -1,9 +1,12 @@
+import logging
 import os
 from collections import UserDict
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from . import utils
 from .merge_dict import MergeDict
+
+logger = logging.getLogger(__name__)
 
 
 class Site(UserDict):
@@ -183,6 +186,28 @@ class Site(UserDict):
                 path = dest.joinpath(relative)
 
         return str(path)
+
+    def run_entry_points_for_group(
+        self, group, default=None, entry_points=None, **kwargs
+    ):
+        """Iterates over `entry_points_for_group` calling the resolved object.
+
+        Args:
+            group (str): The name of the group of entry_points to process.
+            default (dict, optional): If the entry_point is not defined, return
+                the entry points defined by this dictionary. This is the contents
+                of the entry_points group, not the entire entry_points dict. For
+                example: `{"gui": "hab_gui.cli:gui"}`
+            entry_points (dict, optional): Use this dictionary instead of the one
+                defined on this Site object.
+            **kwargs: Any other kwargs are passed to the loaded entry_point record.
+        """
+        for ep in self.entry_points_for_group(
+            group, default=default, entry_points=entry_points
+        ):
+            logger.debug(f"Running {group} entry_point: {ep}")
+            func = ep.load()
+            func(**kwargs)
 
     def standardize_platform_path_maps(self):
         """Ensure the mappings defined in platform_path_maps are converted to

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -343,6 +343,10 @@ class NotSet(object):
         singleton so it does not copy itself."""
         return self
 
+    def __reduce__(self):
+        """Enable pickling of NotSet."""
+        return type(self).__qualname__
+
 
 # Make this a singleton so it works like a boolean False for if statements.
 NotSet = NotSet()

--- a/tests/hab_test_entry_points.py
+++ b/tests/hab_test_entry_points.py
@@ -25,6 +25,31 @@ def cfg_reduce_finalize(cfg):
     )
 
 
+def site_add_paths(site):
+    """Add a couple of extra site paths to hab using `hab.site.add_paths` entry_point."""
+    from pathlib import Path
+
+    return [
+        Path(__file__).parent / "site" / "eps" / "site_add_paths_a.json",
+        Path(__file__).parent / "site" / "eps" / "site_add_paths_b.json",
+    ]
+
+
+def site_add_paths_a(site):
+    """Add a couple of extra site paths to hab using `hab.site.add_paths` entry_point."""
+    from pathlib import Path
+
+    return [
+        Path(__file__).parent / "site" / "eps" / "site_add_paths_c.json",
+    ]
+
+
+def site_finalize(site):
+    """Used to test that an entry point is called by raising an exception when
+    called. See `tests/site/eps/README.md` for details."""
+    raise NotImplementedError("hab_test_entry_points.site_finalize called successfully")
+
+
 def uri_validate_error(resolver, uri):
     """Used to test that an entry point is called by raising an exception when
     called. See `tests/site/eps/README.md` for details."""

--- a/tests/hab_test_entry_points.py
+++ b/tests/hab_test_entry_points.py
@@ -9,6 +9,22 @@ def gui_alt():
     raise NotImplementedError("hab_test_entry_points.gui_alt called successfully")
 
 
+def cfg_reduce_env(cfg):
+    """Used to test that an entry point is called by raising an exception when
+    called. See `tests/site/eps/README.md` for details."""
+    raise NotImplementedError(
+        "hab_test_entry_points.cfg_reduce_env called successfully"
+    )
+
+
+def cfg_reduce_finalize(cfg):
+    """Used to test that an entry point is called by raising an exception when
+    called. See `tests/site/eps/README.md` for details."""
+    raise NotImplementedError(
+        "hab_test_entry_points.cfg_reduce_finalize called successfully"
+    )
+
+
 def uri_validate_error(resolver, uri):
     """Used to test that an entry point is called by raising an exception when
     called. See `tests/site/eps/README.md` for details."""

--- a/tests/hab_test_entry_points.py
+++ b/tests/hab_test_entry_points.py
@@ -7,3 +7,41 @@ def gui_alt():
     """Used to test entry point resolution site modification. Raises an exception
     for ease of testing."""
     raise NotImplementedError("hab_test_entry_points.gui_alt called successfully")
+
+
+def uri_validate_error(resolver, uri):
+    """Used to test that an entry point is called by raising an exception when
+    called. See `tests/site/eps/README.md` for details."""
+    raise NotImplementedError(
+        "hab_test_entry_points.uri_validate_error called successfully"
+    )
+
+
+def uri_validate_project_a(resolver, uri):
+    """Used to test hab.uri.validate entry_point."""
+    from hab.parsers import HabBase
+
+    # Show how the URI can be modified by validation
+    splits = uri.split(HabBase.separator)
+    lower = splits[0].lower()
+    if lower == "project_a" and splits[0] != lower:
+        splits[0] = "project_a"
+        uri = HabBase.separator.join(splits)
+        return uri
+
+
+def uri_validate_project_b(resolver, uri):
+    """Used to test multiple hab.uri.validate entry_points."""
+    from hab.parsers import HabBase
+
+    # Raising an exception stops processing
+    if uri == "raise-error":
+        raise Exception('URI "raise-error" was used, raising an exception.')
+
+    # Show how the URI can be modified by validation
+    splits = uri.split(HabBase.separator)
+    upper = splits[0].upper()
+    if upper == "PROJECT_B" and splits[0] != upper:
+        splits[0] = "PROJECT_B"
+        uri = HabBase.separator.join(splits)
+        return uri

--- a/tests/site/eps/README.md
+++ b/tests/site/eps/README.md
@@ -1,0 +1,3 @@
+This directory contains site json files used to test that each hab entry_point
+is called. Each site file should only enable the specific entry_point being
+tested.

--- a/tests/site/eps/cfg_reduce_env.json
+++ b/tests/site/eps/cfg_reduce_env.json
@@ -1,0 +1,9 @@
+{
+    "append": {
+        "entry_points": {
+            "hab.cfg.reduce.env": {
+                "a": "hab_test_entry_points:cfg_reduce_env"
+            }
+        }
+    }
+}

--- a/tests/site/eps/cfg_reduce_finalize.json
+++ b/tests/site/eps/cfg_reduce_finalize.json
@@ -1,0 +1,9 @@
+{
+    "append": {
+        "entry_points": {
+            "hab.cfg.reduce.finalize": {
+                "a": "hab_test_entry_points:cfg_reduce_finalize"
+            }
+        }
+    }
+}

--- a/tests/site/eps/cfg_uri_validate.json
+++ b/tests/site/eps/cfg_uri_validate.json
@@ -1,0 +1,9 @@
+{
+    "append": {
+        "entry_points": {
+            "hab.uri.validate": {
+                "a": "hab_test_entry_points:uri_validate_error"
+            }
+        }
+    }
+}

--- a/tests/site/eps/site_add_paths.json
+++ b/tests/site/eps/site_add_paths.json
@@ -1,0 +1,12 @@
+{
+    "set": {
+        "test_data": "site_add_paths.json"
+    },
+    "append": {
+        "entry_points": {
+            "hab.site.add_paths": {
+                "main": "hab_test_entry_points:site_add_paths"
+            }
+        }
+    }
+}

--- a/tests/site/eps/site_add_paths_a.json
+++ b/tests/site/eps/site_add_paths_a.json
@@ -1,0 +1,13 @@
+{
+    "set": {
+        "test_data": "site_add_paths_a.json"
+    },
+    "append": {
+        "entry_points": {
+            "hab.site.add_paths": {
+                "main": "hab_test_entry_points:site_add_paths",
+                "a": "hab_test_entry_points:site_add_paths_a"
+            }
+        }
+    }
+}

--- a/tests/site/eps/site_add_paths_b.json
+++ b/tests/site/eps/site_add_paths_b.json
@@ -1,0 +1,5 @@
+{
+    "set": {
+        "test_data": "site_add_paths_b.json"
+    }
+}

--- a/tests/site/eps/site_add_paths_c.json
+++ b/tests/site/eps/site_add_paths_c.json
@@ -1,0 +1,5 @@
+{
+    "set": {
+        "test_data": "site_add_paths_c.json"
+    }
+}

--- a/tests/site/eps/site_finalize.json
+++ b/tests/site/eps/site_finalize.json
@@ -1,0 +1,9 @@
+{
+    "append": {
+        "entry_points": {
+            "hab.site.finalize": {
+                "main": "hab_test_entry_points:site_finalize"
+            }
+        }
+    }
+}

--- a/tests/site/site_ep_uri_validate.json
+++ b/tests/site/site_ep_uri_validate.json
@@ -1,0 +1,10 @@
+{
+    "append": {
+        "entry_points": {
+            "hab.uri.validate": {
+                "project_a": "hab_test_entry_points:uri_validate_project_a",
+                "project_b": "hab_test_entry_points:uri_validate_project_b"
+            }
+        }
+    }
+}

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -523,6 +523,14 @@ class TestEntryPoints:
         "site_file,except_match",
         (
             (
+                "cfg_reduce_env.json",
+                "hab_test_entry_points.cfg_reduce_env called successfully",
+            ),
+            (
+                "cfg_reduce_finalize.json",
+                "hab_test_entry_points.cfg_reduce_finalize called successfully",
+            ),
+            (
                 "cfg_uri_validate.json",
                 "hab_test_entry_points.uri_validate_error called successfully",
             ),


### PR DESCRIPTION
Adds several entry_points to hab to allow for:
- Validating and correcting URI's
- Dynamically configuring site
- Dynamically configuring resolved configs

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
