### PR TITLE
Include HAB_FREEZE when using `Config.launch`

### DIFF
--- a/hab/cli.py
+++ b/hab/cli.py
@@ -579,9 +579,7 @@ def dump(settings, uri, env, env_config, report_type, flat, verbosity, format_ty
         # This is a seperate set of if/elif/else statements than from above.
         # I became confused while reading so decided to add this reminder.
         if format_type == "freeze":
-            ret = encode_freeze(
-                ret.freeze(), version=resolver.site.get("freeze_version")
-            )
+            ret = encode_freeze(ret.freeze(), site=resolver.site)
         elif format_type == "json":
             ret = dumps_json(ret.freeze(), indent=2)
         elif format_type == "versions":

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -658,7 +658,8 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
                 specific environment variable changes.
             include_global (bool, optional): Used to disable adding the global
                 hab managed env vars. Disable this and use alias_name to only
-                get the env vars set by the alias, not the global ones.
+                get the env vars set by the alias, not the global ones. This
+                also adds `HAB_FREEZE` if possible.
             formatter (hab.formatter.Formatter, optional): Str formatter class
                 used to format the env var values.
         """
@@ -678,6 +679,12 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
 
         if include_global:
             _apply(self.environment)
+            # Add the HAB_FREEZE environment variable documenting the entire
+            # resolved hab configuration.
+            if hasattr(self, "freeze") and "HAB_FREEZE" not in env:
+                env["HAB_FREEZE"] = utils.encode_freeze(
+                    self.freeze(), site=self.resolver.site
+                )
         if alias_name:
             _apply(self.aliases[alias_name].get("environment", {}))
 

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -732,7 +732,7 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
         )
         if hasattr(self, "freeze"):
             kwargs["freeze"] = utils.encode_freeze(
-                self.freeze(), version=self.resolver.site.get("freeze_version")
+                self.freeze(), site=self.resolver.site
             )
         if launch:
             # Write additional args into the launch command. This may not properly

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -218,7 +218,7 @@ def dumps_json(data, **kwargs):
     return _json.dumps(data, **kwargs)
 
 
-def encode_freeze(data, version=None):
+def encode_freeze(data, version=None, site=None):
     """Encodes the provided data object in json. This string is stored on the
     "HAB_FREEZE" environment variable when run by the cli.
 
@@ -234,7 +234,12 @@ def encode_freeze(data, version=None):
         data: The data to freeze.
         version (int, optional): The version to encode the freeze with.
             If None is passed, then the default version encoding is used.
+        site (hab.site.Site, optional): If version is not specified, then
+            attempt to get version from `site.get("freeze_version")`.
     """
+    if version is None and site:
+        version = site.get("freeze_version")
+
     if version is None:
         # The current default is 2. Using None makes it easy to control this
         # with a site configuration.

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -197,3 +197,14 @@ def test_encode_freeze(config_root, resolver):
     # Check that other version encodings return nothing
     assert utils.encode_freeze(freeze, version=0) is None
     assert utils.encode_freeze(freeze, version=3) is None
+
+    # Check that site kwarg is respected
+    site = Site()
+    # Force the site to version 1, but version is not specified
+    site["freeze_version"] = 1
+    version1 = utils.encode_freeze(freeze, version=None, site=site)
+    assert version1 == checks["version1"]
+
+    # If version is passed, site is ignored
+    version1 = utils.encode_freeze(freeze, version=2, site=site)
+    assert version1 == checks["version2"]

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -930,15 +930,24 @@ def test_update_environ(resolver):
     def new_dict():
         return dict(inherited)
 
+    def check_freeze(env):
+        # Ensure the HAB_FREEZE variable was actually set on env and remove
+        # it to make checking the rest of the dict easier.
+        freeze = env.pop("HAB_FREEZE")
+        # Check that it starts with the version identifier.
+        assert re.match(r"v\d*:.+", freeze)
+
     # Check that global env vars were added
     env = new_dict()
     cfg.update_environ(env)
+    check_freeze(env)
     assert env == check_global
 
     # And that variables are removed that are set to unset
     env = {"ALIASED_GLOBAL_E": "To be removed"}
     env.update(inherited)
     cfg.update_environ(env)
+    check_freeze(env)
     assert env == check_global
 
     # Check aliased env vars are passed excluding global hab env vars
@@ -967,6 +976,7 @@ def test_update_environ(resolver):
     # Check aliased env vars are passed including global hab env vars
     env = new_dict()
     cfg.update_environ(env, alias_name="as_str", include_global=True)
+    check_freeze(env)
     assert env == check_global
 
     # Check aliased env vars are passed including global hab env vars
@@ -975,4 +985,5 @@ def test_update_environ(resolver):
     check = dict(check_global, **check_alias)
     # This env var is un-set by the alias
     del check["ALIASED_GLOBAL_D"]
+    check_freeze(env)
     assert env == check


### PR DESCRIPTION
This omission is preventing us from passing the current hab configuration(HAB_FREEZE ) to the farm when using hab-gui's launcher. This prevents the farm from properly restoring the correct environment elsewhere.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
