### PR TITLE
Add caching mechanism to speed up loading

### DIFF
--- a/hab/cache.py
+++ b/hab/cache.py
@@ -1,0 +1,230 @@
+import glob
+import json
+import logging
+from pathlib import Path
+
+from packaging.version import InvalidVersion
+
+from . import utils
+from .errors import InvalidVersionError, _IgnoredVersionError
+
+logger = logging.getLogger(__name__)
+
+
+class Cache:
+    """Used to save/restore cached data to speed up initialization of hab.
+
+    The caches are stored per-site file as file next to the site file using the
+    same stem name. (Ie by default studio.json would have a cache file called
+    studio.habcache).
+
+    If this cache file exists it is used unless enabled is set to False. Cache
+    files are useful when you have some sort of CI setup to ensure the cache is
+    re-generated using `save_cache` any time you make changes to configs or
+    distros that site file references.
+
+    Properties:
+        cache_template (dict): The str.format template used to find the cache files.
+            This template requires the kwarg `stem`. This template can be overridden
+            by the first `site_cache_file_template` property in site.
+        enabled (bool): Used to disable using of the cached data forcing a full
+            glob and parse of files described by all site files.
+    """
+
+    supported_version = 1
+
+    def __init__(self, site):
+        self.site = site
+        self._cache = None
+        self.enabled = True
+
+        # Get the template filename used to find the cache files on disk
+        self.cache_template = self.site["site_cache_file_template"][0]
+
+    @property
+    def cached_keys(self):
+        """A dict of cache keys and how they should be processed.
+        {Name of key to cache: ("relative file glob", class used to process)}
+        """
+        try:
+            return self._cached_keys
+        except AttributeError:
+            pass
+
+        from .parsers import Config, DistroVersion
+
+        self._cached_keys = {
+            "config_paths": ("*.json", Config),
+            "distro_paths": ("*/.hab.json", DistroVersion),
+        }
+        return self._cached_keys
+
+    def cache(self, force=False):
+        if not self.enabled:
+            # If caching is disabled, never attempt to load the cache
+            return {}
+
+        if self._cache is not None and not force:
+            return self._cache
+
+        self._cache = {}
+
+        # Process caches from right to left. This makes it so the left most
+        # cache_file is respected if any paths are duplicated.
+        for path in reversed(self.site.paths):
+            cache_file = self.site_cache_path(path)
+            if cache_file.is_file():
+                logger.debug(f"Site cache loading: {cache_file!s}")
+                self.load_cache(cache_file)
+
+        # Create a flattened cache removing the glob paths.
+        flat_cache = {key: {} for key in self.cached_keys}
+        for key in self._cache:
+            for values in self._cache.get(key, {}).values():
+                flat_cache[key].update(values)
+
+        self._cache["flat"] = flat_cache
+
+        return self._cache
+
+    def clear(self):
+        """Reset the cache forcing it to reload the next time its used."""
+        if self._cache:
+            logger.debug("Site cache contents cleared")
+        self._cache = None
+
+    def config_paths(self, flat=False):
+        if flat:
+            return self.cache().get("flat", {}).get("config_paths", {})
+        return self.cache().get("config_paths", {})
+
+    def distro_paths(self, flat=False):
+        if flat:
+            return self.cache().get("flat", {}).get("distro_paths", {})
+        return self.cache().get("distro_paths", {})
+
+    def generate_cache(self, resolver, site_file, version=1):
+        """Generate a cache file of the current state defined by this site file.
+        This contains the raw values of each URI config and distro file including
+        version. If this cache exists it is used instead of searching the file
+        system for each path defined in config_paths or distro_paths defined in
+        the provided site file. Use this method any time changes are made that
+        hab needs to be aware of. Caching is enabled by the existence of this file.
+        """
+        from .site import Site
+
+        # Indicate the version specification this habcache file conforms to.
+        output = {"version": version}
+
+        # read the site file to get paths to process
+        temp_site = Site([site_file])
+        # Use this to convert platform specific paths to generic variables
+        platform_path_key = resolver.site.platform_path_key
+
+        for key, stats in self.cached_keys.items():
+            glob_str, cls = stats
+            # Process each glob dir defined for this site
+            for dirname in temp_site.get(key, []):
+                cfg_paths = output.setdefault(key, {}).setdefault(
+                    platform_path_key(dirname).as_posix(), {}
+                )
+
+                # Add each found hab config to the cache
+                for path in sorted(glob.glob(str(dirname / glob_str))):
+                    path = Path(path)
+                    try:
+                        data = cls(forest={}, resolver=resolver)._load(
+                            path, cached=False
+                        )
+                    except (
+                        InvalidVersion,
+                        InvalidVersionError,
+                        _IgnoredVersionError,
+                    ) as error:
+                        logger.debug(str(error))
+                    else:
+                        cfg_paths[platform_path_key(path).as_posix()] = data
+
+        return output
+
+    @classmethod
+    def iter_cache_paths(cls, name, paths, cache, glob_str=None, include_path=True):
+        """Yields path information stored in the cache falling back to glob if
+        not cached.
+
+        Yields:
+            dirname: Each path stored in paths.
+            path
+        """
+        for dirname in paths:
+            dn_posix = dirname.as_posix()
+            cached = dn_posix in cache
+            if cached:
+                logger.debug(f"Using cache for {name} dir: {dn_posix}")
+                paths = cache[dn_posix]
+            else:
+                logger.debug(f"Using glob for {name} dir: {dirname}")
+                # Fallback to globing the file system
+                if glob_str:
+                    paths = sorted(glob.glob(str(dirname / glob_str)))
+                else:
+                    paths = []
+            if not include_path:
+                yield dirname, None, cached
+            else:
+                for path in paths:
+                    yield dirname, path, cached
+
+    def load_cache(self, filename, platform=None):
+        """For each glob dir add or replace the contents. If a previous cache
+        has the same glob dir, it's cache is ignored. This expects that
+        load_cache is called from right to left for each path in `self.site.path`.
+        """
+
+        def cache_to_platform(cache, mappings):
+            """Restore the cross-platform variables to current platform paths."""
+            ret = {}
+            for glob_str, files in cache.items():
+                new_glob = glob_str.format(**mappings)
+                new_glob = Path(new_glob).as_posix()
+                new_files = {}
+                for key, value in files.items():
+                    new_key = key.format(**mappings)
+                    new_key = Path(new_key).as_posix()
+                    new_files[new_key] = value
+                ret[new_glob] = new_files
+
+            return ret
+
+        if platform is None:
+            platform = utils.Platform.name()
+
+        contents = utils.load_json_file(filename)
+
+        # If the cache was saved by a newer habcache system, warn that we are
+        # unable to load the cache but don't raise an exception
+        if contents["version"] > self.supported_version:
+            logger.warning(
+                f"File is using a unsupported habcache version {contents['version']}. "
+                f"Only versions > {self.supported_version} are supported, ignoring {filename}"
+            )
+            return
+
+        mappings = self.site.get("platform_path_maps", {})
+        mappings = {key: value[platform] for key, value in mappings.items()}
+        for key in self.cached_keys:
+            if key in contents:
+                cache = cache_to_platform(contents[key], mappings)
+                self._cache.setdefault(key, {}).update(cache)
+
+    def save_cache(self, resolver, site_file, version=1):
+        cache_file = self.site_cache_path(site_file)
+        cache = self.generate_cache(resolver, site_file, version=version)
+
+        with cache_file.open("w") as fle:
+            json.dump(cache, fle, indent=4, cls=utils.HabJsonEncoder)
+        return cache_file
+
+    def site_cache_path(self, path):
+        """Returns the name of the cache file for the given site file."""
+        return path.parent / self.cache_template.format(stem=path.stem)

--- a/hab/parsers/config.py
+++ b/hab/parsers/config.py
@@ -18,6 +18,9 @@ class Config(HabBase):
         self._alias_mods = NotSet
         super().__init__(*args, **kwargs)
 
+    def _cache(self):
+        return self.resolver.site.cache.config_paths(flat=True)
+
     @hab_property(process_order=120)
     def aliases(self):
         """Dict of the names and commands that need created to launch desired

--- a/hab/parsers/distro_version.py
+++ b/hab/parsers/distro_version.py
@@ -18,6 +18,66 @@ class DistroVersion(HabBase):
         self._alias_mods = NotSet
         super().__init__(*args, **kwargs)
 
+    def _cache(self):
+        return self.resolver.site.cache.distro_paths(flat=True)
+
+    def _resolve_version(self, data, filename):
+        """Sets and returns self.version to the correct value for this distro.
+
+        This resolves the version from the several ways it can be stored to
+        simplify deployment and development. See InvalidVersionError for details
+        on how distros version can be set.
+
+        Raises:
+            _IgnoredVersionError: Internal use, this version should not be processed.
+            InvalidVersionError: Raised if the version could not be resolved.
+        """
+        version_txt = self.dirname / ".hab_version.txt"
+
+        if "version" in data:
+            self.version = data["version"]
+            return self.version
+        elif version_txt.exists():
+            self.version = version_txt.open().read().strip()
+            return self.version
+
+        # If version is not defined in json data extract it from the parent
+        # directory name. This allows for simpler distribution without needing
+        # to modify version controlled files.
+        try:
+            self.version = self.dirname.name
+            return self.version
+        except InvalidVersion:
+            """The parent directory was not a valid version, attempt to get a
+            version using setuptools_scm.
+            """
+            try:
+                from setuptools_scm import get_version
+            except ImportError as error:
+                raise InvalidVersionError(filename, error=error) from None
+
+            def check_ignored_version():
+                if self.dirname.name in self.resolver.ignored:
+                    # This object is not added to the forest until super is called
+                    raise _IgnoredVersionError(
+                        'Skipping "{}" its dirname is in the ignored list.'.format(
+                            filename
+                        )
+                    ) from None
+
+            try:
+                self.version = get_version(
+                    root=self.dirname, version_scheme="release-branch-semver"
+                )
+                return self.version
+            except LookupError:
+                check_ignored_version()
+                raise InvalidVersionError(filename) from None
+            except Exception as error:
+                check_ignored_version()
+                # To make debugging easier include the original exception
+                raise InvalidVersionError(filename, error=error) from None
+
     @hab_property()
     def aliases(self):
         """List of the names and commands that need created to launch desired
@@ -38,6 +98,18 @@ class DistroVersion(HabBase):
         """
         return self._alias_mods
 
+    def _load(self, filename, cached=True):
+        """Sets self.filename and parses the json file returning the data."""
+        ret = super()._load(filename, cached=cached)
+
+        # Resolve the version from the various supported ways its stored.
+        self._resolve_version(ret, filename)
+
+        if not cached:
+            # Ensure the version is stored on the returned dictionary
+            ret["version"] = str(self.version)
+        return ret
+
     def load(self, filename):
         # Fill in the DistroVersion specific settings before calling super
         data = self._load(filename)
@@ -45,48 +117,6 @@ class DistroVersion(HabBase):
         self.aliases = data.get("aliases", NotSet)
         # Store any alias_mods, they will be processed later when flattening
         self._alias_mods = data.get("alias_mods", NotSet)
-
-        # The version can be stored in several ways to make deployment and dev easier
-        version_txt = self.dirname / ".hab_version.txt"
-        if "version" in data:
-            self.version = data["version"]
-        elif version_txt.exists():
-            self.version = version_txt.open().read().strip()
-        else:
-            # If version is not defined in json data extract it from the parent
-            # directory name. This allows for simpler distribution without needing
-            # to modify version controlled files.
-            try:
-                self.version = self.dirname.name
-            except InvalidVersion:
-                """The parent directory was not a valid version, attempt to get a
-                version using setuptools_scm.
-                """
-                try:
-                    from setuptools_scm import get_version
-                except ImportError as error:
-                    raise InvalidVersionError(self.filename, error=error) from None
-
-                def check_ignored_version():
-                    if self.dirname.name in self.resolver.ignored:
-                        # This object is not added to the forest until super is called
-                        raise _IgnoredVersionError(
-                            'Skipping "{}" its dirname is in the ignored list.'.format(
-                                filename
-                            )
-                        ) from None
-
-                try:
-                    self.version = get_version(
-                        root=self.dirname, version_scheme="release-branch-semver"
-                    )
-                except LookupError:
-                    check_ignored_version()
-                    raise InvalidVersionError(self.filename) from None
-                except Exception as error:
-                    check_ignored_version()
-                    # To make debugging easier include the original exception
-                    raise InvalidVersionError(self.filename, error=error) from None
 
         # The name should be the version == specifier.
         self.distro_name = data.get("name")

--- a/hab/resolver.py
+++ b/hab/resolver.py
@@ -57,12 +57,6 @@ class Resolver(object):
         else:
             self.forced_requirements = {}
 
-        self.config_paths = utils.Platform.expand_paths(
-            self.site.get("config_paths", [])
-        )
-        self.distro_paths = utils.Platform.expand_paths(
-            self.site.get("distro_paths", [])
-        )
         logger.debug("config_paths: {}".format(self.config_paths))
         logger.debug("distro_paths: {}".format(self.distro_paths))
 
@@ -144,7 +138,7 @@ class Resolver(object):
 
     @property
     def config_paths(self):
-        return self._config_paths
+        return self.site["config_paths"]
 
     @config_paths.setter
     def config_paths(self, paths):
@@ -152,7 +146,7 @@ class Resolver(object):
         if isinstance(paths, str):
             paths = utils.Platform.expand_paths(paths)
 
-        self._config_paths = paths
+        self.site["config_paths"] = paths
         # Reset _configs so we re-generate them the next time they are requested
         self._configs = None
 
@@ -165,7 +159,7 @@ class Resolver(object):
 
     @property
     def distro_paths(self):
-        return self._distro_paths
+        return self.site["distro_paths"]
 
     @distro_paths.setter
     def distro_paths(self, paths):
@@ -173,7 +167,7 @@ class Resolver(object):
         if isinstance(paths, str):
             paths = utils.Platform.expand_paths(paths)
 
-        self._distro_paths = paths
+        self.site["distro_paths"] = paths
         # Reset _distros so we re-generate them the next time they are requested
         self._distros = None
 

--- a/hab/site.py
+++ b/hab/site.py
@@ -160,6 +160,10 @@ class Site(UserDict):
                 self.paths.insert(0, path)
                 self.load_file(path)
 
+        # Convert config_paths and distro_paths to lists of Path objects
+        self["config_paths"] = utils.Platform.expand_paths(self["config_paths"])
+        self["distro_paths"] = utils.Platform.expand_paths(self["distro_paths"])
+
         # Ensure any platform_path_maps are converted to pathlib objects.
         self.standardize_platform_path_maps()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 from contextlib import contextmanager
 from pathlib import Path, PurePath
@@ -7,17 +8,107 @@ from packaging.requirements import Requirement
 
 from hab import Resolver, Site
 
+# Testing both cached and uncached every time adds extra testing time. This env
+# var can be used to disable cached testing for local testing.
+if os.getenv("HAB_TEST_UNCACHED_ONLY", "0") == "1":
+    resolver_tests = ["uncached"]
+else:
+    resolver_tests = ["uncached", "cached"]
 
-@pytest.fixture
+
+@pytest.fixture(scope="session")
 def config_root():
     return Path(__file__).parent
 
 
+def generate_habcached_site_file(config_root, dest):
+    """Returns the path to a site config file generated from `site_main.json`
+    configured so it can have a .habcache file generated next to it. The
+    config_paths and distro_paths of the site file are hard coded to point to
+    the repo's tests directory so it uses the same configs/distros. It also adds
+    a `config-root` entry to `platform_path_maps`.
+    """
+    site_file = Path(dest) / "site.json"
+    site_src = config_root / "site_main.json"
+
+    # Load the site_main.json files contents so we can modify it before saving
+    # it into the dest for testing.
+    data = json.load(site_src.open())
+    append = data["append"]
+
+    # Hard code relative_root to the tests folder so it works from
+    # a random testing directory without copying all configs/distros.
+    for key in ("config_paths", "distro_paths"):
+        for i in range(len(append[key])):
+            append[key][i] = append[key][i].format(relative_root=site_src.parent)
+
+    # Add platform_path_maps for the pytest directory to simplify testing and
+    # test cross-platform support. We need to add all platforms, but this only
+    # needs to run on the current platform, so add the same path to all.
+    append["platform_path_maps"]["config-root"] = {
+        platform: str(config_root) for platform in data["set"]["platforms"]
+    }
+
+    with site_file.open("w") as fle:
+        json.dump(data, fle, indent=4)
+
+    return site_file
+
+
+@pytest.fixture(scope="session")
+def habcached_site_file(config_root, tmp_path_factory):
+    """Generates a site.json file and generates its habcache file.
+    This file is stored in a `_cache` directory in the pytest directory.
+    This persists for the entire testing session and can be used by other tests
+    that need to test hab when it is using a habcache.
+    """
+    # Create the site file
+    shared = tmp_path_factory.mktemp("_cache")
+    ret = generate_habcached_site_file(config_root, shared)
+
+    # Generate the habcache file
+    site = Site([ret])
+    resolver = Resolver(site)
+    site.cache.save_cache(resolver, ret)
+
+    return ret
+
+
 @pytest.fixture
-def resolver(config_root):
-    """Return a standard testing resolver"""
+def habcached_resolver(habcached_site_file):
+    """Returns a Resolver using a habcache file that was generated for this session.
+
+    See the `habcached_site_file` fixture for details on how the cache is setup.
+    For ease of testing the path to the saved habcache file is stored in
+    `_test_cache_file` on the returned resolver.
+    """
+    site = Site([habcached_site_file])
+    resolver = Resolver(site)
+    # Generate the cache and provide easy access to the habcache file path
+    resolver._test_cache_file = site.cache.site_cache_path(habcached_site_file)
+
+    return resolver
+
+
+@pytest.fixture
+def uncached_resolver(config_root):
+    """Return a standard testing resolver not using any habcache files."""
     site = Site([config_root / "site_main.json"])
     return Resolver(site=site)
+
+
+@pytest.fixture(params=resolver_tests)
+def resolver(request):
+    """Returns a hab.Resolver instance using the site_main.json site config file.
+
+    This is a parameterized fixture that returns both cached and uncached versions
+    of the `site_main.json` site configuration. Note the cached version uses a
+    copy of it stored in the `_cache0` directory of the pytest temp files. This
+    should be used for most tests to ensure that all features are tested, but if
+    the test is not affected by caching you can use `uncached_resolver` instead.
+    """
+    test_map = {"uncached": "uncached_resolver", "cached": "habcached_resolver"}
+    return request.getfixturevalue(test_map[request.param])
 
 
 class Helpers(object):

--- a/tests/distros/the_dcc/pre/.hab.json
+++ b/tests/distros/the_dcc/pre/.hab.json
@@ -1,0 +1,14 @@
+{
+    "name": "the_dcc",
+    "environment": {},
+    "distros": [
+        "the_dcc_plugin_a>=1.0",
+        "the_dcc_plugin_b>=0.9",
+        "the_dcc_plugin_e"
+    ],
+    "aliases": {
+        "windows": [
+            ["dcc", "{relative_root}\\the_dcc.exe"]
+        ]
+    }
+}

--- a/tests/distros/the_dcc/pre/README.md
+++ b/tests/distros/the_dcc/pre/README.md
@@ -1,0 +1,3 @@
+This directory enables testing that hab ignores distro version folders defined
+in the `ignored_distros` key of the site configuration. It's version is pulled
+from the parent directory of the .hab.json file, which is named `pre`.

--- a/tests/hab_test_entry_points.py
+++ b/tests/hab_test_entry_points.py
@@ -86,3 +86,14 @@ def uri_validate_project_b(resolver, uri):
         splits[0] = "PROJECT_B"
         uri = HabBase.separator.join(splits)
         return uri
+
+
+class CacheVX:
+    """Used to validate that the entry_point `hab_habcache_cls` is respected by
+    raising an exception when initialized.
+
+    Note: A real example of this class would subclass `hab.cache.Cache`.
+    """
+
+    def __init__(self, site):
+        raise NotImplementedError("hab_test_entry_points.CacheVX class was used")

--- a/tests/site/eps/site_habcache_cls.json
+++ b/tests/site/eps/site_habcache_cls.json
@@ -1,0 +1,9 @@
+{
+    "append": {
+        "entry_points": {
+            "hab.habcache_cls": {
+                "cls": "hab_test_entry_points:CacheVX"
+            }
+        }
+    }
+}

--- a/tests/site/site_cache_file.json
+++ b/tests/site/site_cache_file.json
@@ -1,0 +1,5 @@
+{
+    "set": {
+        "site_cache_file_template": ".{{stem}}.hab_cache"
+    }
+}

--- a/tests/site_main_check.habcache
+++ b/tests/site_main_check.habcache
@@ -1,0 +1,1433 @@
+{
+    "version": 1,
+    "config_paths": {
+        "{config-root}/configs/*": {
+            "{config-root}/configs/app/app_aliased.json": {
+                "name": "aliased",
+                "context": [
+                    "app"
+                ],
+                "inherits": false,
+                "distros": [
+                    "aliased"
+                ]
+            },
+            "{config-root}/configs/app/app_aliased_config.json": {
+                "name": "config",
+                "context": [
+                    "app",
+                    "aliased"
+                ],
+                "inherits": true,
+                "alias_mods": {
+                    "as_dict": {
+                        "environment": {
+                            "os_specific": true,
+                            "linux": {
+                                "prepend": {
+                                    "ALIASED_LOCAL": "{relative_root}/config",
+                                    "ALIASED_MOD_LOCAL_A": "Local Config A"
+                                }
+                            },
+                            "windows": {
+                                "prepend": {
+                                    "ALIASED_LOCAL": "{relative_root}/config",
+                                    "ALIASED_MOD_LOCAL_A": "Local Config A"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "{config-root}/configs/app/app_aliased_mod.json": {
+                "name": "mod",
+                "context": [
+                    "app",
+                    "aliased"
+                ],
+                "inherits": true,
+                "distros": [
+                    "aliased",
+                    "aliased_mod"
+                ],
+                "environment": {
+                    "set": {
+                        "CONFIG_DEFINED": "config_variable"
+                    }
+                }
+            },
+            "{config-root}/configs/app/app_aliased_mod_config.json": {
+                "name": "config",
+                "context": [
+                    "app",
+                    "aliased",
+                    "mod"
+                ],
+                "inherits": true,
+                "alias_mods": {
+                    "as_dict": {
+                        "environment": {
+                            "os_specific": true,
+                            "linux": {
+                                "prepend": {
+                                    "ALIASED_LOCAL": "{relative_root}/config_mod",
+                                    "ALIASED_MOD_LOCAL_A": "Local Config Mod A"
+                                }
+                            },
+                            "windows": {
+                                "prepend": {
+                                    "ALIASED_LOCAL": "{relative_root}/config_mod",
+                                    "ALIASED_MOD_LOCAL_A": "Local Config Mod A"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "{config-root}/configs/app/app_houdini_a.json": {
+                "name": "a",
+                "context": [
+                    "app",
+                    "houdini"
+                ],
+                "description": "Test that the duplicated alias houdini is resolved against 18.5.",
+                "inherits": false,
+                "distros": [
+                    "houdini18.5",
+                    "houdini19.5"
+                ]
+            },
+            "{config-root}/configs/app/app_houdini_b.json": {
+                "name": "b",
+                "context": [
+                    "app",
+                    "houdini"
+                ],
+                "description": "Test that the duplicated alias houdini is resolved against 19.5.",
+                "inherits": false,
+                "distros": [
+                    "houdini19.5",
+                    "houdini18.5"
+                ]
+            },
+            "{config-root}/configs/app/app_maya.json": {
+                "name": "maya",
+                "context": [
+                    "app"
+                ],
+                "inherits": false,
+                "min_verbosity": {
+                    "global": 2,
+                    "hab": 2,
+                    "hab-gui": 1
+                }
+            },
+            "{config-root}/configs/app/app_maya_2020.json": {
+                "name": "2020",
+                "context": [
+                    "app",
+                    "maya"
+                ],
+                "inherits": true,
+                "distros": [
+                    "maya2020"
+                ]
+            },
+            "{config-root}/configs/default/default.json": {
+                "name": "default",
+                "context": [],
+                "inherits": false,
+                "distros": {
+                    "maya2020": [
+                        "the_dcc_plugin_a",
+                        "the_dcc_plugin_b",
+                        "the_dcc_plugin_c"
+                    ],
+                    "houdini18.5": [
+                        "the_dcc_plugin_d"
+                    ]
+                }
+            },
+            "{config-root}/configs/default/default_Sc1.json": {
+                "name": "Sc1",
+                "context": [
+                    "default"
+                ],
+                "inherits": false,
+                "distros": {
+                    "maya2020": [
+                        "the_dcc_plugin_a",
+                        "the_dcc_plugin_b",
+                        "the_dcc_plugin_c"
+                    ],
+                    "houdini18.5": [
+                        "the_dcc_plugin_d"
+                    ]
+                }
+            },
+            "{config-root}/configs/default/default_Sc11.json": {
+                "name": "Sc11",
+                "context": [
+                    "default"
+                ],
+                "inherits": false,
+                "distros": {
+                    "maya2020": [
+                        "the_dcc_plugin_a",
+                        "the_dcc_plugin_b",
+                        "the_dcc_plugin_c"
+                    ],
+                    "houdini18.5": [
+                        "the_dcc_plugin_d"
+                    ]
+                }
+            },
+            "{config-root}/configs/not_set/child.json": {
+                "name": "child",
+                "context": [
+                    "not_set"
+                ],
+                "environment": {
+                    "unset": [
+                        "UNSET_VARIABLE"
+                    ],
+                    "set": {
+                        "TEST": "case",
+                        "FMT_FOR_OS": "a{;}b;c:{PATH!e}{;}d"
+                    }
+                },
+                "inherits": true
+            },
+            "{config-root}/configs/not_set/env.json": {
+                "name": "env1",
+                "context": [
+                    "not_set"
+                ],
+                "environment": {
+                    "unset": [
+                        "UNSET_VARIABLE",
+                        "UNSET_VARIABLE_1",
+                        "RELATIVE_VARIABLE"
+                    ],
+                    "set": {
+                        "SET_RELATIVE": "{relative_root}",
+                        "RELATIVE_VARIABLE": "{relative_root}/set",
+                        "SET_VARIABLE": "set_value",
+                        "MAYA_MODULE_PATH": "MMP_Set"
+                    },
+                    "append": {
+                        "RELATIVE_VARIABLE": "{relative_root}/append",
+                        "APPEND_VARIABLE": "append_value"
+                    },
+                    "prepend": {
+                        "RELATIVE_VARIABLE": "{relative_root}/prepend",
+                        "PREPEND_VARIABLE": "prepend_value"
+                    }
+                },
+                "inherits": true
+            },
+            "{config-root}/configs/not_set/env_path_hab_uri.json": {
+                "name": "env_path_hab_uri",
+                "context": [
+                    "not_set"
+                ],
+                "environment": {
+                    "set": {
+                        "HAB_URI": "invalid value"
+                    }
+                },
+                "inherits": true
+            },
+            "{config-root}/configs/not_set/env_path_set.json": {
+                "name": "env_path_set",
+                "context": [
+                    "not_set"
+                ],
+                "environment": {
+                    "set": {
+                        "PATH": "path_variable"
+                    }
+                },
+                "inherits": true
+            },
+            "{config-root}/configs/not_set/env_path_unset.json": {
+                "name": "env_path_unset",
+                "context": [
+                    "not_set"
+                ],
+                "environment": {
+                    "unset": [
+                        "PATH"
+                    ]
+                },
+                "inherits": true
+            },
+            "{config-root}/configs/not_set/not_set.json": {
+                "name": "not_set",
+                "context": [],
+                "inherits": false,
+                "distros": [
+                    "aliased",
+                    "maya2020"
+                ]
+            },
+            "{config-root}/configs/not_set/not_set_distros.json": {
+                "name": "distros",
+                "context": [
+                    "not_set"
+                ],
+                "inherits": false,
+                "distros": {
+                    "the_dcc": []
+                },
+                "environment": {
+                    "append": {
+                        "Test": "Case"
+                    }
+                }
+            },
+            "{config-root}/configs/not_set/not_set_empty_lists.json": {
+                "name": "empty_lists",
+                "context": [
+                    "not_set"
+                ],
+                "inherits": false,
+                "aliases": [],
+                "distros": []
+            },
+            "{config-root}/configs/not_set/not_set_no_distros.json": {
+                "name": "no_distros",
+                "context": [
+                    "not_set"
+                ],
+                "inherits": false,
+                "environment": {
+                    "append": {
+                        "Test": "Case"
+                    }
+                }
+            },
+            "{config-root}/configs/not_set/not_set_no_env.json": {
+                "name": "no_env",
+                "context": [
+                    "not_set"
+                ],
+                "inherits": false,
+                "distros": {
+                    "the_dcc": []
+                }
+            },
+            "{config-root}/configs/not_set/os_env.json": {
+                "name": "os",
+                "context": [
+                    "not_set"
+                ],
+                "environment": {
+                    "os_specific": true,
+                    "linux": {
+                        "unset": [
+                            "UNSET_VARIABLE_LIN"
+                        ],
+                        "set": {
+                            "SET_VARIABLE_LIN": "set_value_lin"
+                        },
+                        "append": {
+                            "APPEND_VARIABLE_LIN": "append_value_lin"
+                        },
+                        "prepend": {
+                            "PREPEND_VARIABLE_LIN": "prepend_value_lin"
+                        }
+                    },
+                    "windows": {
+                        "unset": [
+                            "UNSET_VARIABLE_WIN"
+                        ],
+                        "set": {
+                            "SET_VARIABLE_WIN": "set_value_win"
+                        },
+                        "append": {
+                            "APPEND_VARIABLE_WIN": "append_value_win"
+                        },
+                        "prepend": {
+                            "PREPEND_VARIABLE_WIN": "prepend_value_win"
+                        }
+                    }
+                },
+                "inherits": false
+            },
+            "{config-root}/configs/place-holder/place-holder_child.json": {
+                "name": "child",
+                "context": [
+                    "place-holder"
+                ],
+                "inherits": false,
+                "distros": [
+                    "the_dcc"
+                ]
+            },
+            "{config-root}/configs/place-holder/place-holder_inherits.json": {
+                "name": "inherits",
+                "context": [
+                    "place-holder"
+                ],
+                "inherits": true,
+                "environment": {
+                    "set": {
+                        "TEST": "case"
+                    }
+                }
+            },
+            "{config-root}/configs/project_a/project_a.json": {
+                "name": "project_a",
+                "context": [],
+                "inherits": false,
+                "distros": [
+                    "maya2020",
+                    "houdini18.5"
+                ]
+            },
+            "{config-root}/configs/project_a/project_a_Sc001.json": {
+                "name": "Sc001",
+                "context": [
+                    "project_a"
+                ],
+                "inherits": true,
+                "distros": [
+                    "maya2020==2020.0"
+                ]
+            },
+            "{config-root}/configs/project_a/project_a_Sc001_animation.json": {
+                "name": "Animation",
+                "context": [
+                    "project_a",
+                    "Sc001"
+                ],
+                "inherits": true,
+                "distros": [
+                    "maya2020"
+                ]
+            },
+            "{config-root}/configs/project_a/project_a_Sc001_rigging.json": {
+                "name": "Rigging",
+                "context": [
+                    "project_a",
+                    "Sc001"
+                ],
+                "inherits": true,
+                "distros": [
+                    "maya2020"
+                ]
+            },
+            "{config-root}/configs/verbosity/verbosity.json": {
+                "name": "verbosity",
+                "context": [],
+                "description": "Defines verbosity settings that can be inherited",
+                "environment": {
+                    "set": {
+                        "VERBOSITY": "verbosity"
+                    }
+                },
+                "inherits": false,
+                "min_verbosity": {
+                    "global": 2,
+                    "hab-gui": 1
+                }
+            },
+            "{config-root}/configs/verbosity/verbosity_hidden.json": {
+                "name": "hidden",
+                "context": [
+                    "verbosity"
+                ],
+                "description": "Verbosity global setting above the normal max of 2. Should only be visible if verbosity is None.",
+                "inherits": true,
+                "environment": {
+                    "set": {
+                        "VERBOSITY": "verbosity/hidden"
+                    }
+                },
+                "min_verbosity": {
+                    "global": 3,
+                    "hab-gui": 2
+                }
+            },
+            "{config-root}/configs/verbosity/verbosity_inherit-no.json": {
+                "name": "inherit-no",
+                "context": [
+                    "verbosity"
+                ],
+                "description": "Doesn't define verbosity and doesn't inherit it from parent.",
+                "inherits": false,
+                "environment": {
+                    "set": {
+                        "VERBOSITY": "verbosity/inherit-no"
+                    }
+                }
+            },
+            "{config-root}/configs/verbosity/verbosity_inherit-override.json": {
+                "name": "inherit-override",
+                "context": [
+                    "verbosity"
+                ],
+                "description": "Inherits from parent but defines verbosity on itself.",
+                "inherits": true,
+                "environment": {
+                    "set": {
+                        "VERBOSITY": "verbosity/inherit-override"
+                    }
+                },
+                "min_verbosity": {
+                    "global": 1
+                }
+            },
+            "{config-root}/configs/verbosity/verbosity_inherit.json": {
+                "name": "inherit",
+                "context": [
+                    "verbosity"
+                ],
+                "description": "Doesn't define verbosity but does inherit it from parent.",
+                "distros": [
+                    "aliased_verbosity"
+                ],
+                "inherits": true,
+                "environment": {
+                    "set": {
+                        "VERBOSITY": "verbosity/inherit"
+                    }
+                }
+            }
+        }
+    },
+    "distro_paths": {
+        "{config-root}/distros/*": {
+            "{config-root}/distros/aliased/2.0/.hab.json": {
+                "name": "aliased",
+                "aliases": {
+                    "linux": [
+                        [
+                            "as_dict",
+                            {
+                                "cmd": [
+                                    "python",
+                                    "{relative_root}/list_vars.py"
+                                ],
+                                "environment": {
+                                    "prepend": {
+                                        "ALIASED_LOCAL": "{relative_root}/test"
+                                    }
+                                }
+                            }
+                        ],
+                        [
+                            "inherited",
+                            {
+                                "cmd": [
+                                    "python",
+                                    "{relative_root}/list_vars.py"
+                                ],
+                                "environment": {
+                                    "append": {
+                                        "PATH": [
+                                            "{PATH!e}",
+                                            "{relative_root}/PATH/env/with  spaces",
+                                            "/mnt/shared_resources/with spaces"
+                                        ]
+                                    }
+                                }
+                            }
+                        ],
+                        [
+                            "as_list",
+                            [
+                                "python",
+                                "{relative_root}/list_vars.py"
+                            ]
+                        ],
+                        [
+                            "as_str",
+                            "python"
+                        ],
+                        [
+                            "global",
+                            {
+                                "cmd": [
+                                    "python",
+                                    "{relative_root}/list_vars.py"
+                                ],
+                                "environment": {
+                                    "append": {
+                                        "ALIASED_GLOBAL_A": "Local A Append"
+                                    },
+                                    "prepend": {
+                                        "ALIASED_GLOBAL_A": "Local A Prepend"
+                                    },
+                                    "set": {
+                                        "ALIASED_GLOBAL_C": "Local C Set"
+                                    },
+                                    "unset": [
+                                        "ALIASED_GLOBAL_D"
+                                    ]
+                                }
+                            }
+                        ]
+                    ],
+                    "windows": [
+                        [
+                            "as_dict",
+                            {
+                                "cmd": [
+                                    "python",
+                                    "{relative_root}/list_vars.py"
+                                ],
+                                "environment": {
+                                    "prepend": {
+                                        "ALIASED_LOCAL": "{relative_root}/test"
+                                    }
+                                }
+                            }
+                        ],
+                        [
+                            "inherited",
+                            {
+                                "cmd": [
+                                    "python",
+                                    "{relative_root}/list_vars.py"
+                                ],
+                                "environment": {
+                                    "append": {
+                                        "PATH": [
+                                            "{PATH!e}",
+                                            "{relative_root}/PATH/env/with  spaces",
+                                            "\\\\example\\shared_resources\\with spaces"
+                                        ]
+                                    }
+                                }
+                            }
+                        ],
+                        [
+                            "as_list",
+                            [
+                                "python",
+                                "{relative_root}/list_vars.py"
+                            ]
+                        ],
+                        [
+                            "as_str",
+                            "python"
+                        ],
+                        [
+                            "global",
+                            {
+                                "cmd": [
+                                    "python",
+                                    "{relative_root}/list_vars.py"
+                                ],
+                                "environment": {
+                                    "append": {
+                                        "ALIASED_GLOBAL_A": "Local A Append"
+                                    },
+                                    "prepend": {
+                                        "ALIASED_GLOBAL_A": "Local A Prepend"
+                                    },
+                                    "set": {
+                                        "ALIASED_GLOBAL_C": "Local C Set"
+                                    },
+                                    "unset": [
+                                        "ALIASED_GLOBAL_D"
+                                    ]
+                                }
+                            }
+                        ]
+                    ]
+                },
+                "environment": {
+                    "append": {
+                        "ALIASED_GLOBAL_A": "Global A"
+                    },
+                    "set": {
+                        "ALIASED_GLOBAL_B": "Global B",
+                        "ALIASED_GLOBAL_C": "Global C",
+                        "ALIASED_GLOBAL_D": "Global D",
+                        "ALIASED_GLOBAL_F": "Global F"
+                    },
+                    "unset": [
+                        "ALIASED_GLOBAL_E"
+                    ]
+                },
+                "version": "2.0"
+            },
+            "{config-root}/distros/aliased_mod/1.0/.hab.json": {
+                "name": "aliased_mod",
+                "description": "Modifies the aliases defined in the aliased distro.",
+                "alias_mods": {
+                    "as_dict": {
+                        "environment": {
+                            "os_specific": true,
+                            "linux": {
+                                "prepend": {
+                                    "ALIASED_LOCAL": "{relative_root}/modified",
+                                    "ALIASED_MOD_LOCAL_A": "Local Mod A"
+                                }
+                            },
+                            "windows": {
+                                "prepend": {
+                                    "ALIASED_LOCAL": "{relative_root}/modified",
+                                    "ALIASED_MOD_LOCAL_A": "Local Mod A"
+                                }
+                            }
+                        }
+                    },
+                    "as_list": {
+                        "environment": {
+                            "os_specific": true,
+                            "linux": {
+                                "prepend": {
+                                    "ALIASED_MOD_LOCAL_B": "Local Mod B"
+                                }
+                            },
+                            "windows": {
+                                "prepend": {
+                                    "ALIASED_MOD_LOCAL_B": "Local Mod B"
+                                }
+                            }
+                        }
+                    },
+                    "global": {
+                        "environment": {
+                            "os_specific": true,
+                            "linux": {
+                                "prepend": {
+                                    "ALIASED_GLOBAL_A": "Local Mod A",
+                                    "ALIASED_MOD_LOCAL_B": "Local Mod B",
+                                    "ALIASED_GLOBAL_F": "Local Mod F"
+                                }
+                            },
+                            "windows": {
+                                "prepend": {
+                                    "ALIASED_GLOBAL_A": "Local Mod A",
+                                    "ALIASED_MOD_LOCAL_B": "Local Mod B",
+                                    "ALIASED_GLOBAL_F": "Local Mod F"
+                                }
+                            }
+                        }
+                    }
+                },
+                "environment": {
+                    "set": {
+                        "ALIASED_MOD_GLOBAL_A": "Global Mod A"
+                    }
+                },
+                "version": "1.0"
+            },
+            "{config-root}/distros/aliased_verbosity/1.0/.hab.json": {
+                "name": "aliased_verbosity",
+                "aliases": {
+                    "linux": [
+                        [
+                            "vb_default",
+                            [
+                                "python"
+                            ]
+                        ],
+                        [
+                            "vb0",
+                            {
+                                "cmd": [
+                                    "python"
+                                ],
+                                "min_verbosity": {
+                                    "global": 0,
+                                    "hab-gui": 3
+                                }
+                            }
+                        ],
+                        [
+                            "vb1",
+                            {
+                                "cmd": [
+                                    "python"
+                                ],
+                                "min_verbosity": {
+                                    "global": 1,
+                                    "hab-gui": 2
+                                }
+                            }
+                        ],
+                        [
+                            "vb2",
+                            {
+                                "cmd": [
+                                    "python"
+                                ],
+                                "min_verbosity": {
+                                    "global": 2,
+                                    "hab-gui": 1
+                                }
+                            }
+                        ],
+                        [
+                            "vb3",
+                            {
+                                "cmd": [
+                                    "python"
+                                ],
+                                "min_verbosity": {
+                                    "global": 3,
+                                    "hab-gui": 0
+                                }
+                            }
+                        ]
+                    ],
+                    "windows": [
+                        [
+                            "vb_default",
+                            [
+                                "python"
+                            ]
+                        ],
+                        [
+                            "vb0",
+                            {
+                                "cmd": [
+                                    "python"
+                                ],
+                                "min_verbosity": {
+                                    "global": 0,
+                                    "hab-gui": 3
+                                }
+                            }
+                        ],
+                        [
+                            "vb1",
+                            {
+                                "cmd": [
+                                    "python"
+                                ],
+                                "min_verbosity": {
+                                    "global": 1,
+                                    "hab-gui": 2
+                                }
+                            }
+                        ],
+                        [
+                            "vb2",
+                            {
+                                "cmd": [
+                                    "python"
+                                ],
+                                "min_verbosity": {
+                                    "global": 2,
+                                    "hab-gui": 1
+                                }
+                            }
+                        ],
+                        [
+                            "vb3",
+                            {
+                                "cmd": [
+                                    "python"
+                                ],
+                                "min_verbosity": {
+                                    "global": 3,
+                                    "hab-gui": 0
+                                }
+                            }
+                        ]
+                    ]
+                },
+                "version": "1.0"
+            },
+            "{config-root}/distros/all_settings/0.1.0.dev1/.hab.json": {
+                "name": "all_settings",
+                "version": "0.1.0.dev1",
+                "environment": {
+                    "unset": [
+                        "OTHER"
+                    ],
+                    "set": {
+                        "TEST": "case"
+                    },
+                    "append": {
+                        "MAYA_MODULE_PATH": "."
+                    },
+                    "prepend": {
+                        "TEST_VARIABLE": "prepend_value"
+                    }
+                },
+                "distros": [
+                    "Maya2020"
+                ],
+                "aliases": {
+                    "windows": [
+                        [
+                            "maya",
+                            "C:\\Program Files\\Autodesk\\Maya2020\\bin\\maya.exe"
+                        ],
+                        [
+                            "mayapy",
+                            "C:\\Program Files\\Autodesk\\Maya2020\\bin\\mayapy.exe"
+                        ]
+                    ]
+                }
+            },
+            "{config-root}/distros/houdini18.5/18.5.351/.hab.json": {
+                "name": "houdini18.5",
+                "version": "18.5.351",
+                "aliases": {
+                    "linux": [
+                        [
+                            "houdini",
+                            "/opt/hfs18.5.351/bin/houdini"
+                        ],
+                        [
+                            "houdini18.5",
+                            {
+                                "cmd": "/opt/hfs18.5.351/bin/houdini",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "houdinicore",
+                            {
+                                "cmd": "/opt/hfs18.5.351/bin/houdinicore",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "hhoudinicore18.5",
+                            {
+                                "cmd": "/opt/hfs18.5.351/bin/houdinicore",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "husk",
+                            {
+                                "cmd": "/opt/hfs18.5.351/bin/husk",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "husk18.5",
+                            {
+                                "cmd": "/opt/hfs18.5.351/bin/husk",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ]
+                    ],
+                    "windows": [
+                        [
+                            "houdini",
+                            "C:\\Program Files\\Side Effects Software\\Houdini 18.5.351\\bin\\houdini.exe"
+                        ],
+                        [
+                            "houdini18.5",
+                            {
+                                "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 18.5.351\\bin\\houdini.exe",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "houdinicore",
+                            {
+                                "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 18.5.351\\bin\\houdinicore.exe"
+                            }
+                        ],
+                        [
+                            "houdinicore18.5",
+                            {
+                                "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 18.5.351\\bin\\houdinicore.exe",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "husk",
+                            {
+                                "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 18.5.351\\bin\\husk.exe",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "husk18.5",
+                            {
+                                "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 18.5.351\\bin\\husk.exe",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ]
+                    ]
+                }
+            },
+            "{config-root}/distros/houdini19.5/19.5.493/.hab.json": {
+                "name": "houdini19.5",
+                "version": "19.5.493",
+                "aliases": {
+                    "linux": [
+                        [
+                            "houdini",
+                            "/opt/hfs19.5.493/bin/houdini"
+                        ],
+                        [
+                            "houdini19.5",
+                            {
+                                "cmd": "/opt/hfs19.5.493/bin/houdini",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "houdinicore",
+                            {
+                                "cmd": "/opt/hfs19.5.493/bin/houdinicore",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "hhoudinicore19.5",
+                            {
+                                "cmd": "/opt/hfs19.5.493/bin/houdinicore",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "husk",
+                            {
+                                "cmd": "/opt/hfs19.5.493/bin/husk",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "husk19.5",
+                            {
+                                "cmd": "/opt/hfs19.5.493/bin/husk",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ]
+                    ],
+                    "windows": [
+                        [
+                            "houdini",
+                            {
+                                "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdini.exe",
+                                "hab.launch_cls": {
+                                    "subprocess": "subprocess:Popen"
+                                }
+                            }
+                        ],
+                        [
+                            "houdini19.5",
+                            {
+                                "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdini.exe",
+                                "min_verbosity": {
+                                    "global": 1
+                                },
+                                "hab.launch_cls": {
+                                    "subprocess": "subprocess:Popen"
+                                }
+                            }
+                        ],
+                        [
+                            "houdinicore",
+                            {
+                                "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdinicore.exe",
+                                "hab.launch_cls": {
+                                    "subprocess": "subprocess:Popen"
+                                }
+                            }
+                        ],
+                        [
+                            "houdinicore19.5",
+                            {
+                                "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\houdinicore.exe",
+                                "min_verbosity": {
+                                    "global": 1
+                                },
+                                "hab.launch_cls": {
+                                    "subprocess": "subprocess:Popen"
+                                }
+                            }
+                        ],
+                        [
+                            "husk",
+                            {
+                                "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\husk.exe",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "husk19.5",
+                            {
+                                "cmd": "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\bin\\husk.exe",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ]
+                    ]
+                }
+            },
+            "{config-root}/distros/maya/2020.0/.hab.json": {
+                "name": "maya2020",
+                "environment": {},
+                "aliases": {
+                    "windows": [
+                        [
+                            "maya",
+                            "C:\\Program Files\\Autodesk\\Maya2020\\bin\\maya.exe"
+                        ],
+                        [
+                            "mayapy",
+                            "C:\\Program Files\\Autodesk\\Maya2020\\bin\\mayapy.exe"
+                        ]
+                    ]
+                },
+                "version": "2020.0"
+            },
+            "{config-root}/distros/maya/2020.1/.hab.json": {
+                "name": "maya2020",
+                "version": "2020.1",
+                "environment": {},
+                "aliases": {
+                    "windows": [
+                        [
+                            "maya",
+                            {
+                                "cmd": "C:\\Program Files\\Autodesk\\Maya2020\\bin\\maya.exe",
+                                "icon": "C:\\Windows\\Installer\\{{0EBFFCF6-F972-4D40-863F-E673B5C38236}}\\maya.ico"
+                            }
+                        ],
+                        [
+                            "mayapy",
+                            {
+                                "cmd": "C:\\Program Files\\Autodesk\\Maya2020\\bin\\mayapy.exe",
+                                "min_verbosity": {
+                                    "global": 2
+                                }
+                            }
+                        ],
+                        [
+                            "maya20",
+                            {
+                                "cmd": "C:\\Program Files\\Autodesk\\Maya2020\\bin\\maya.exe",
+                                "icon": "C:\\Windows\\Installer\\{{0EBFFCF6-F972-4D40-863F-E673B5C38236}}\\maya.ico",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "mayapy20",
+                            {
+                                "cmd": "C:\\Program Files\\Autodesk\\Maya2020\\bin\\mayapy.exe",
+                                "min_verbosity": {
+                                    "global": 2
+                                }
+                            }
+                        ],
+                        [
+                            "pip",
+                            {
+                                "cmd": [
+                                    "C:\\Program Files\\Autodesk\\Maya2020\\bin\\mayapy.exe",
+                                    "-m",
+                                    "pip"
+                                ],
+                                "min_verbosity": {
+                                    "global": 2
+                                }
+                            }
+                        ]
+                    ],
+                    "linux": [
+                        [
+                            "maya",
+                            {
+                                "cmd": "/usr/local/bin/maya2020"
+                            }
+                        ],
+                        [
+                            "mayapy",
+                            {
+                                "cmd": "/usr/local/bin/mayapy2020",
+                                "min_verbosity": {
+                                    "global": 2
+                                }
+                            }
+                        ],
+                        [
+                            "maya20",
+                            {
+                                "cmd": "/usr/local/bin/maya2020",
+                                "min_verbosity": {
+                                    "global": 1
+                                }
+                            }
+                        ],
+                        [
+                            "mayapy20",
+                            {
+                                "cmd": "/usr/local/bin/mayapy2020",
+                                "min_verbosity": {
+                                    "global": 2
+                                }
+                            }
+                        ],
+                        [
+                            "pip",
+                            {
+                                "cmd": [
+                                    "/usr/local/bin/mayapy2020",
+                                    "-m",
+                                    "pip"
+                                ],
+                                "min_verbosity": {
+                                    "global": 2
+                                }
+                            }
+                        ]
+                    ]
+                }
+            },
+            "{config-root}/distros/the_dcc/1.0/.hab.json": {
+                "name": "the_dcc",
+                "environment": {},
+                "distros": [
+                    "the_dcc_plugin_a>=1.0",
+                    "the_dcc_plugin_b>=0.9",
+                    "the_dcc_plugin_e"
+                ],
+                "aliases": {
+                    "windows": [
+                        [
+                            "dcc",
+                            "{relative_root}\\the_dcc.exe"
+                        ]
+                    ]
+                },
+                "version": "1.0"
+            },
+            "{config-root}/distros/the_dcc/1.1/.hab.json": {
+                "name": "the_dcc",
+                "environment": {},
+                "distros": [
+                    "the_dcc_plugin_a>=1.0"
+                ],
+                "aliases": {
+                    "windows": [
+                        [
+                            "dcc",
+                            "{relative_root}\\the_dcc.exe"
+                        ]
+                    ]
+                },
+                "version": "1.1"
+            },
+            "{config-root}/distros/the_dcc/1.2/.hab.json": {
+                "name": "the_dcc",
+                "environment": {},
+                "distros": [
+                    "the_dcc_plugin_a>=1.0",
+                    "the_dcc_plugin_b>=0.9",
+                    "the_dcc_plugin_e"
+                ],
+                "aliases": {
+                    "linux": [
+                        [
+                            "dcc",
+                            "{relative_root}//the_dcc"
+                        ]
+                    ],
+                    "windows": [
+                        [
+                            "dcc",
+                            "{relative_root}\\the_dcc.exe"
+                        ]
+                    ]
+                },
+                "version": "1.2"
+            },
+            "{config-root}/distros/the_dcc_plugin_a/0.9/.hab.json": {
+                "name": "the_dcc_plugin_a",
+                "distros": [
+                    "the_dcc_plugin_d",
+                    "the_dcc_plugin_e<2.0",
+                    "the_dcc<1.2"
+                ],
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    }
+                },
+                "version": "0.9"
+            },
+            "{config-root}/distros/the_dcc_plugin_a/1.0/.hab.json": {
+                "name": "the_dcc_plugin_a",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    }
+                },
+                "version": "1.0"
+            },
+            "{config-root}/distros/the_dcc_plugin_a/1.1/.hab.json": {
+                "name": "the_dcc_plugin_a",
+                "distros": [
+                    "the_dcc_plugin_e<2.0",
+                    "the_dcc_plugin_d"
+                ],
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}",
+                        "DCC_CONFIG_PATH": "{relative_root}"
+                    }
+                },
+                "version": "1.1"
+            },
+            "{config-root}/distros/the_dcc_plugin_b/0.9/.hab.json": {
+                "name": "the_dcc_plugin_b",
+                "distros": [
+                    "the_dcc<1.2"
+                ],
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    }
+                },
+                "version": "0.9"
+            },
+            "{config-root}/distros/the_dcc_plugin_b/1.0/.hab.json": {
+                "name": "the_dcc_plugin_b",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    }
+                },
+                "version": "1.0"
+            },
+            "{config-root}/distros/the_dcc_plugin_b/1.1/.hab.json": {
+                "name": "the_dcc_plugin_b",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    },
+                    "prepend": {
+                        "DCC_CONFIG_PATH": "{relative_root}"
+                    }
+                },
+                "version": "1.1"
+            },
+            "{config-root}/distros/the_dcc_plugin_c/0.9/.hab.json": {
+                "name": "the_dcc_plugin_c",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    }
+                },
+                "version": "0.9"
+            },
+            "{config-root}/distros/the_dcc_plugin_c/1.0/.hab.json": {
+                "name": "the_dcc_plugin_c",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    }
+                },
+                "version": "1.0"
+            },
+            "{config-root}/distros/the_dcc_plugin_c/1.1/.hab.json": {
+                "name": "the_dcc_plugin_c",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    }
+                },
+                "version": "1.1"
+            },
+            "{config-root}/distros/the_dcc_plugin_d/0.9/.hab.json": {
+                "name": "the_dcc_plugin_d",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    }
+                },
+                "version": "0.9"
+            },
+            "{config-root}/distros/the_dcc_plugin_d/1.0/.hab.json": {
+                "name": "the_dcc_plugin_d",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    }
+                },
+                "version": "1.0"
+            },
+            "{config-root}/distros/the_dcc_plugin_d/1.1/.hab.json": {
+                "name": "the_dcc_plugin_d",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    },
+                    "prepend": {
+                        "DCC_CONFIG_PATH": "{relative_root}"
+                    }
+                },
+                "version": "1.1"
+            },
+            "{config-root}/distros/the_dcc_plugin_e/0.9/.hab.json": {
+                "name": "the_dcc_plugin_e",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    }
+                },
+                "version": "0.9"
+            },
+            "{config-root}/distros/the_dcc_plugin_e/1.0/.hab.json": {
+                "name": "the_dcc_plugin_e",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}"
+                    }
+                },
+                "version": "1.0"
+            },
+            "{config-root}/distros/the_dcc_plugin_e/1.1/.hab.json": {
+                "name": "the_dcc_plugin_e",
+                "environment": {
+                    "append": {
+                        "DCC_MODULE_PATH": "{relative_root}",
+                        "DCC_CONFIG_PATH": "{relative_root}"
+                    }
+                },
+                "version": "1.1"
+            }
+        }
+    }
+}

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,166 @@
+import json
+from pathlib import Path
+
+from hab import Resolver, Site
+from hab.cache import Cache
+from hab.parsers import Config, DistroVersion, HabBase
+
+
+def test_cached_keys(uncached_resolver):
+    check = {
+        "config_paths": ("*.json", Config),
+        "distro_paths": ("*/.hab.json", DistroVersion),
+    }
+
+    cache = uncached_resolver.site.cache
+    # Container variable is not set by default
+    assert not hasattr(cache, "_cached_keys")
+    # On first call generates the correct return value
+    assert cache.cached_keys == check
+    # And stored the value in the container variable
+    assert hasattr(cache, "_cached_keys")
+
+    # Verify that the cached value is returned once generated
+    cache._cached_keys = "Test value"
+    assert cache.cached_keys == "Test value"
+
+
+def test_site_cache_path(config_root, uncached_resolver, tmpdir):
+    cache = uncached_resolver.site.cache
+
+    # Test default
+    site_file = Path(tmpdir) / "test.json"
+    assert cache.cache_template == "{stem}.habcache"
+    assert cache.site_cache_path(site_file) == tmpdir / "test.habcache"
+
+    # Test that cache_template is respected
+    cache.cache_template = "<{stem}>.ext"
+    assert cache.site_cache_path(site_file) == tmpdir / "<test>.ext"
+
+    # Test that `site_cache_file_template` site config setting is respected
+    site = Site([config_root / "site" / "site_cache_file.json"])
+    assert site.cache.cache_template == ".{stem}.hab_cache"
+
+
+def test_save_cache(config_root, tmpdir, habcached_resolver):
+    # Check that the habcache file generated the expected output text
+    # Note: This file will need updated as the test configuration is updated
+    check = (config_root / "site_main_check.habcache").open().readlines()
+    cache = habcached_resolver._test_cache_file.open().readlines()
+    # Add trailing white space to match template file's trailing white space
+    cache[-1] += "\n"
+    assert len(cache) == len(check)
+    for i in range(len(cache)):
+        assert cache[i] == check[i]
+
+
+def test_load_cache(config_root, uncached_resolver, habcached_site_file):
+    """Tests non-cached resolved data matches a reference cached version."""
+    cached_site = Site([habcached_site_file])
+    cached_resolver = Resolver(cached_site)
+
+    # Load the reference cache. In normal operation _cache is None until the
+    # first time `.cache` is called, but for this test we won't be doing that.
+    cached_site.cache._cache = {}
+    cached_site.cache.load_cache(config_root / "site_main_check.habcache")
+
+    # Check that un-cached resolver settings match the reference cache
+    for key in ("config_paths", "distro_paths"):
+        assert getattr(uncached_resolver, key) == getattr(cached_resolver, key)
+
+
+def test_unsupported_version_warning(uncached_resolver, tmpdir, caplog):
+    cache_file = Path(tmpdir) / "test.habcache"
+    warn_msg = (
+        "File is using a unsupported habcache version {}. "
+        f"Only versions > {{}} are supported, ignoring {cache_file}"
+    )
+
+    def _load_cache_version(version, cls=Cache):
+        # Generate a test cache for the given version number
+        with cache_file.open("w") as fle:
+            json.dump({"version": version}, fle)
+
+        cache = cls(uncached_resolver.site)
+        cache._cache = {}
+        caplog.clear()
+        cache.load_cache(cache_file)
+        return [rec.message for rec in caplog.records]
+
+    # No warning if version is supported
+    assert _load_cache_version(1) == []
+    # Warning logged if cache version is newer than supported_version
+    assert _load_cache_version(2) == [warn_msg.format(2, 1)]
+
+    # Warning is logged correctly for higher supported versions
+    class CacheV2(Cache):
+        supported_version = 2
+
+    assert _load_cache_version(1, cls=CacheV2) == []
+    assert _load_cache_version(2, cls=CacheV2) == []
+    assert _load_cache_version(3, cls=CacheV2) == [warn_msg.format(3, 2)]
+
+
+def test_cached_method(config_root, habcached_site_file):
+    """Test the Cache.cache method options."""
+    cached_site = Site([habcached_site_file])
+    cache = cached_site.cache
+    assert cache.enabled is True
+
+    # At this point _cache is None
+    assert cache._cache is None
+    # Simulate the cache already being loaded
+    cache._cache = "Test value"
+    assert cache.cache() == "Test value"
+
+    # Forcing the cache to reload, re-generates a cache
+    result = cache.cache(force=True)
+    assert isinstance(result, dict)
+    assert len(result)
+
+    # Check that disabling caching causes the cache to not be returned
+    cache.enabled = False
+    assert cache.enabled is False
+    result = cache.cache()
+    assert isinstance(result, dict)
+    assert not len(result)
+
+    # Check that HabBase._cache returns a empty dict.
+    assert HabBase(None, None)._cache() == {}
+
+
+def test_resolver_cache(request, resolver):
+    """Tests that cached and uncached resolvers actually use/don't use the cache.
+
+    `uncached_resolver` should not have a habcache file and shouldn't use a cache.
+    `habcached_resolver` should have a habcache and uses it.
+    """
+    # Figure out if this is the cached or uncached resolver test
+    is_cached = "habcached_resolver" in request.fixturenames
+
+    # Get the site file path
+    assert len(resolver.site.paths) == 1
+    site_file = resolver.site.paths[0]
+    cache_file = resolver.site.cache.site_cache_path(site_file)
+
+    # The .habcache file should only exist when testing cached
+    if is_cached:
+        assert cache_file.exists()
+    else:
+        assert not cache_file.exists()
+
+    # force the resolver to load config/distro information
+    resolver.resolve("not_set")
+
+    cache = resolver.site.cache._cache
+    if is_cached:
+        # This habcache setup has exactly one cached glob string
+        assert len(cache["config_paths"]) == 1
+        assert len(cache["distro_paths"]) == 1
+        # The flat cache has many configs/distros, the test only needs to ensure
+        # that we have gotten some results
+        assert len(cache["flat"]["config_paths"]) > 10
+        assert len(cache["flat"]["distro_paths"]) > 10
+    else:
+        # If there aren't any habcache files, a default dict is returned
+        assert cache == {"flat": {"config_paths": {}, "distro_paths": {}}}

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -53,9 +53,9 @@ def test_language_from_ext(monkeypatch):
         assert Formatter.language_from_ext("") == "sh"
 
 
-def test_format_environment_value(resolver):
+def test_format_environment_value(uncached_resolver):
     forest = {}
-    config = Config(forest, resolver)
+    config = Config(forest, uncached_resolver)
 
     # test_format_environment_value doesn't replace the special formatters.
     # This allows us to delay these formats to only when creating the final

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -140,7 +140,7 @@ def test_unfreeze(config_root, resolver):
     assert cfg.alias_mods is NotSet
 
 
-def test_decode_freeze(config_root, resolver):
+def test_decode_freeze(config_root):
     check_file = config_root / "frozen_no_distros.json"
     checks = utils.json.load(check_file.open())
     v1 = checks["version1"]

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -749,6 +749,18 @@ def test_clear_caches(resolver):
     assert resolver._distros is None
 
 
+def test_clear_caches_cached(habcached_resolver):
+    """Test that Resolver.clear_cache works when using a habcache."""
+
+    # Populate resolver cache data
+    habcached_resolver.resolve("not_set")
+    assert isinstance(habcached_resolver.site.cache._cache, dict)
+    assert len(habcached_resolver.site.cache._cache)
+
+    habcached_resolver.clear_caches()
+    assert habcached_resolver.site.cache._cache is None
+
+
 def test_uri_validate(config_root):
     """Test the `hab.uri.validate` entry_point."""
     resolver = Resolver(

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -14,7 +14,7 @@ reference_names = [x.name for x in reference_scripts.iterdir()]
 
 
 @pytest.mark.parametrize("reference_name", reference_names)
-def test_scripts(resolver, tmpdir, monkeypatch, config_root, reference_name):
+def test_scripts(uncached_resolver, tmpdir, monkeypatch, config_root, reference_name):
     """Checks all of the scripts HabBase.write_script generates for a specified
     set of arguments.
 
@@ -62,7 +62,7 @@ def test_scripts(resolver, tmpdir, monkeypatch, config_root, reference_name):
     assert platform in ("linux", "osx", "win32")
     monkeypatch.setattr(utils, "Platform", utils.BasePlatform.get_platform(platform))
 
-    cfg = resolver.resolve(spec["uri"])
+    cfg = uncached_resolver.resolve(spec["uri"])
     reference = config_root / "reference_scripts" / reference_name
     ext = spec["ext"]
 
@@ -172,7 +172,7 @@ def test_scripts(resolver, tmpdir, monkeypatch, config_root, reference_name):
 
 
 @pytest.mark.skip(reason="Find a way to test complex alias evaluation in pytest")
-def test_complex_alias_bat(tmpdir, config_root, resolver):
+def test_complex_alias_bat(tmpdir, config_root):
     """This test is a placeholder for a future that can actually call hab's `hab.cli`
     and its aliases to check that they function correctly in Batch.
 
@@ -209,7 +209,7 @@ def test_complex_alias_bat(tmpdir, config_root, resolver):
 
 
 @pytest.mark.skip(reason="Find a way to test complex alias evaluation in pytest")
-def test_complex_alias_ps1(tmpdir, config_root, resolver):
+def test_complex_alias_ps1(tmpdir, config_root):
     """This test is a placeholder for a future that can actually call hab's `hab.cli`
     and its aliases to check that they function correctly in PowerShell.
 
@@ -246,7 +246,7 @@ def test_complex_alias_ps1(tmpdir, config_root, resolver):
 
 
 @pytest.mark.skip(reason="Find a way to test complex alias evaluation in pytest")
-def test_complex_alias_sh(tmpdir, config_root, resolver):
+def test_complex_alias_sh(tmpdir, config_root):
     """This test is a placeholder for a future that can actually call hab's `hab.cli`
     and its aliases to check that they function correctly in Bash.
 
@@ -283,14 +283,14 @@ def test_complex_alias_sh(tmpdir, config_root, resolver):
 
 
 @pytest.mark.parametrize("ext", (".bat", ".ps1", ".sh"))
-def test_invalid_alias(resolver, tmpdir, ext):
+def test_invalid_alias(uncached_resolver, tmpdir, ext):
     """Check that useful errors are raised if an invalid alias is passed or if
     the alias doesn't have "cmd" defined.
     """
     kwargs = dict(ext=ext, exit=True, args=None, create_launch=True)
 
     # Check that calling a bad alias name raises a useful error message
-    cfg = resolver.resolve("not_set/child")
+    cfg = uncached_resolver.resolve("not_set/child")
     with pytest.raises(errors.HabError, match=r'"bad-alias" is not a valid alias name'):
         cfg.write_script(str(tmpdir), launch="bad-alias", **kwargs)
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,5 +1,5 @@
 import sys
-from pathlib import PurePosixPath, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import colorama
 import pytest
@@ -282,8 +282,8 @@ class TestOsSpecific:
         paths = [config_root / "site_os_specific.json"]
         site = Site(paths)
 
-        assert site.get("config_paths") == ["config/path/linux"]
-        assert site.get("distro_paths") == ["distro/path/linux"]
+        assert site.get("config_paths") == [Path("config/path/linux")]
+        assert site.get("distro_paths") == [Path("distro/path/linux")]
         assert site.get("platforms") == ["windows", "linux"]
 
     def test_osx(self, monkeypatch, config_root):
@@ -295,8 +295,8 @@ class TestOsSpecific:
         paths = [config_root / "site_os_specific.json"]
         site = Site(paths)
 
-        assert site.get("config_paths") == ["config/path/osx"]
-        assert site.get("distro_paths") == ["distro/path/osx"]
+        assert site.get("config_paths") == [Path("config/path/osx")]
+        assert site.get("distro_paths") == [Path("distro/path/osx")]
         assert site.get("platforms") == ["osx", "linux"]
 
     def test_win(self, monkeypatch, config_root):
@@ -308,8 +308,8 @@ class TestOsSpecific:
         paths = [config_root / "site_os_specific.json"]
         site = Site(paths)
 
-        assert site.get("config_paths") == ["config\\path\\windows"]
-        assert site.get("distro_paths") == ["distro\\path\\windows"]
+        assert site.get("config_paths") == [Path("config\\path\\windows")]
+        assert site.get("distro_paths") == [Path("distro\\path\\windows")]
         assert site.get("platforms") == ["windows", "osx"]
 
 

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -62,14 +62,14 @@ def test_simplify_requirements(helpers, value, check):
         ),
     ),
 )
-def test_invalid_requirement_errors(resolver, requirements, match):
+def test_invalid_requirement_errors(uncached_resolver, requirements, match):
     """Test that the correct error is raised if an invalid or missing requirement
     is specified."""
     with pytest.raises(InvalidRequirementError, match=match):
-        resolver.resolve_requirements(requirements)
+        uncached_resolver.resolve_requirements(requirements)
 
 
-def test_solver_errors(resolver):
+def test_solver_errors(uncached_resolver):
     """Test that the correct errors are raised"""
 
     # Check that if we exceed max_redirects a MaxRedirectError is raised
@@ -83,7 +83,7 @@ def test_solver_errors(resolver):
         )
     )
 
-    solver = Solver(requirements, resolver)
+    solver = Solver(requirements, uncached_resolver)
     solver.max_redirects = 0
     with pytest.raises(MaxRedirectError, match="Redirect limit of 0 reached"):
         solver.resolve()

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,9 @@ skipsdist = True
 [testenv]
 changedir = {toxinidir}
 skip_install = True
-passenv = GITHUB_ACTIONS
+passenv =
+    GITHUB_ACTIONS
+    HAB_TEST_UNCACHED_ONLY
 deps =
     -rrequirements.txt
     covdefaults


### PR DESCRIPTION
The more distros and configs you have the slower hab becomes. Especially if you have a lot of them on the network. The biggest bottleneck is the globs on windows. There is also likely some slowness for json parsing every file individually.

This saves a cache of the configs and distros on a per-site basis. I the cache exists it is used instead of scanning the file system.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [ ] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
