### PR TITLE
Fix bug in forced requirements when inheriting distros

### DIFF
--- a/hab/parsers/flat_config.py
+++ b/hab/parsers/flat_config.py
@@ -38,6 +38,13 @@ class FlatConfig(Config):
         # Run any configured entry_points before aliases are calculated
         self.resolver.site.run_entry_points_for_group("hab.cfg.reduce.env", cfg=self)
 
+        # Ensure distros are populated before versions get processed
+        if self.distros is NotSet:
+            if self.resolver.forced_requirements:
+                self.distros = self.resolver.forced_requirements
+            else:
+                self.distros = {}
+
         # Process version aliases, merging global env vars.
         platform_aliases = {}
         self.frozen_data["aliases"] = platform_aliases
@@ -207,10 +214,7 @@ class FlatConfig(Config):
     def versions(self):
         distros = self.distros
         if distros is NotSet:
-            if self.resolver.forced_requirements:
-                distros = {}
-            else:
-                return []
+            return []
         if distros == []:
             distros = {}
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -535,6 +535,29 @@ def test_forced_requirements(resolver, helpers, forced, check, check_versions):
         assert v.name == check_versions[i]
 
 
+def test_forced_requirements_uri(resolver, helpers):
+    resolver_forced = Resolver(
+        site=resolver.site,
+        forced_requirements={"houdini19.5": Requirement("houdini19.5")},
+    )
+    # We are checking cfg.versions, so these need to be resolved to `==` requirements
+    check = ["aliased==2.0", "houdini19.5==19.5.493"]
+
+    def cfg_versions_to_dict(cfg):
+        return {v.distro_name: Requirement(v.name) for v in cfg.versions}
+
+    # Forced requirement includes direct distro assignments from the config
+    cfg = resolver_forced.resolve("app/aliased")
+    versions = cfg_versions_to_dict(cfg)
+    helpers.assert_requirements_equal(versions, check)
+
+    # Check that forced requirements are correctly applied even if a config
+    # inherits it's distros from a parent config.
+    cfg = resolver_forced.resolve("app/aliased/config")
+    versions = cfg_versions_to_dict(cfg)
+    helpers.assert_requirements_equal(versions, check)
+
+
 @pytest.mark.parametrize(
     "value,check",
     (


### PR DESCRIPTION
If using a URI config that inherits distros, attempting to add a forced_requirement would case the inherited distros to be lost and it would only get the forced requirements. For example see `hab -r houdini19.5 dump app/aliased -v` without this fix.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->

These examples use the site config `site_main.json`.

Without the patch, if you run `hab -r houdini19.5 dump app/aliased/config -v`, the versions report incorrectly shows `versions:  houdini19.5==19.5.493`. It should include `aliased==2.0` from the distros inherited from the `app/aliased` URI.

With the patch applied the same command returns the correct: `versions:  aliased==2.0, houdini19.5==19.5.493`