### PR TITLE
Add shared Resolver.instance classmethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,35 @@ an int value or None. If not specified(ie None), then the default version is use
 
 ## API
 
-TODO
+Simple example of resolving an hab URI using the python api.
+```py
+import hab
+
+# Ensure the env var `HAB_PATHS` is set pointing to one or more site files.
+resolver = hab.Resolver.instance()
+# Load the config for the given URI
+cfg = resolver.resolve("app/aliased")
+# Launch the alias and run a command in a sub-process
+proc = cfg.launch("as_str", ["-c", "print('done')"])
+```
+The `hab.Resolver.instance()` call allows you to cache the configuration of all
+configs and distros so they only need to be processed once. This allows isolated
+code to access the same resolver information without needing a storage variable.
+If you need more than one shared instance of `Resolver` you can pass name to
+`hab.Resolver.instance(name="studio")`. You can also pass any kwargs that
+`hab.Resolver` accepts, but they are ignored after the first call
+(`hab.Resolver.instance(name="studio", site=studio_site)`).
+
+The above examples are relying on the `HAB_PATHS` env var to define site. You can
+also directly define a Site.
+```py
+import hab
+from pathlib import Path
+
+root = Path(r'/mnt/studio/config')
+site = hab.Site([root / "site_main.json", root / "site_override.json"])
+resolver = hab.Resolver(site=site)
+```
 
 ## Configuration
 
@@ -1223,7 +1251,7 @@ import hab
 
 # Resolve the hab configuration
 hab_uri = 'app/aliased'
-resolver = hab.Resolver()
+resolver = hab.Resolver.instance()
 cfg = resolver.resolve(hab_uri)
 
 # Launch the processes concurrently

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -802,3 +802,32 @@ def test_uri_validate(config_root):
     assert resolver.resolve("pRoJect_A/CammelCase").uri == "pRoJect_A/CammelCase"
     assert resolver.resolve("pRoJect_B/CammelCase").uri == "pRoJect_B/CammelCase"
     assert resolver.resolve("proJECT_c/CammelCase").uri == "proJECT_c/CammelCase"
+
+
+def test_instance(config_root):
+    # Check that a resolver instance is created and returned on first call,
+    # respecting passed in arguments.
+    assert Resolver._instances == {}
+    site = Site([config_root / "site_main.json"])
+    resolver = Resolver.instance(name="instance_test", site=site, target="test")
+    assert resolver is Resolver._instances["instance_test"]
+    assert resolver.site is site
+    assert resolver._verbosity_target == "test"
+
+    # **kwargs are ignored if you try to access the same instance a again.
+    site1 = Site([config_root / "site_main.json", config_root / "site_override.json"])
+    resolver1 = Resolver.instance(
+        name="instance_test", site=site1, target="ignored_target"
+    )
+    # The same resolver instance was returned
+    assert resolver1 is resolver
+    # The kwargs were ignored on the second call
+    assert resolver1.site is site
+    assert resolver1._verbosity_target == "test"
+
+    # **kwargs are not ignored if requesting a new resolver name.
+    resolver2 = Resolver.instance(name="another_ins", site=site1, target="new")
+    assert resolver2 is Resolver._instances["another_ins"]
+    assert resolver2 is not resolver
+    assert resolver2.site is site1
+    assert resolver2._verbosity_target == "new"


### PR DESCRIPTION
This makes it possible for individual code paths to reference the same Resolver instance, preventing each of them from having to re-process the hab configuration.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
