### PR TITLE
Allow passing of a frozen hab string to UnfrozenConfig

### DIFF
--- a/hab/parsers/unfrozen_config.py
+++ b/hab/parsers/unfrozen_config.py
@@ -1,7 +1,7 @@
 import logging
 from copy import deepcopy
 
-from .. import NotSet
+from .. import NotSet, utils
 from .config import Config
 from .meta import hab_property
 
@@ -9,8 +9,21 @@ logger = logging.getLogger(__name__)
 
 
 class UnfrozenConfig(Config):
-    def __init__(self, frozen_data, resolver, uri=NotSet, forest=None):
+    """Config class specifically for thawing frozen hab config data.
+
+    Args:
+        frozen_data (dict or str): The frozen data to thaw. Ultimately this needs
+            to be the dict returned by `FlatConfig.freeze`. If a dict is passed
+            it is used directly. If a string is passed `hab.utils.decode_freeze`
+            is called on it and the resulting dict is used.
+        resolver (hab.Resolver): The Resolver used to lookup non-frozen data.
+    """
+
+    def __init__(self, frozen_data, resolver):
         super().__init__(None, resolver)
+        if isinstance(frozen_data, str):
+            # If a str is passed, assume its a frozen string and decode it
+            frozen_data = utils.decode_freeze(frozen_data)
         self.frozen_data = deepcopy(frozen_data)
 
         # Restore the HAB_URI env variable that was removed during freeze

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -139,6 +139,18 @@ def test_unfreeze(config_root, resolver):
     # already baked into aliases
     assert cfg.alias_mods is NotSet
 
+    # Check passing a string to UnfrozenConfig instead of a dict
+    check_file = config_root / "frozen_no_distros.json"
+    checks = utils.json.load(check_file.open())
+    v2 = checks["version2"]
+    cfg = UnfrozenConfig(v2, resolver)
+
+    # The HAB_URI env var is included in the frozen config on a UnfrozenConfig
+    check = checks["raw"]
+    check["environment"]["linux"]["HAB_URI"] = check["uri"]
+    check["environment"]["windows"]["HAB_URI"] = check["uri"]
+    assert cfg.frozen_data == check
+
 
 def test_decode_freeze(config_root):
     check_file = config_root / "frozen_no_distros.json"


### PR DESCRIPTION
Simplify and document __init__ for UnfrozenConfig.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
