### PR TITLE
Add distro name and version information to each alias dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,12 +933,26 @@ defined as a two part list where the first item is the name of the created alias
 command. The second argument is the actual command to run and configuration
 definition.
 
-Ultimately all alias definitions are turned into dictionaries like `as_dict`, but
-you can also define aliases as lists of strings or a single string. It's
-recommended that you use a list of strings for any commands that require multiple
-arguments, for more details see args documentation in
+Ultimately all alias definitions are turned into [dictionaries](#complex-aliases)
+like `as_dict`, but you can also define aliases as lists of strings or a single
+string. It's recommended that you use a list of strings for any commands that
+require multiple arguments, for more details see args documentation in
 [subprocess.Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen).
 
+When the aliases are converted to dicts, they automatically get a "distro" key
+added to them. This contains a two item tuple containing the `distro_name` and
+`version`. This is preserved when frozen. You can use this to track down what
+distro created a [duplicate alias](#duplicate-definitions). This is also useful
+if you need to tie a farm job to a specific version of a dcc based on the active
+hab setup.
+```py
+import hab
+import os
+
+resolver = hab.Resolver.instance()
+cfg = resolver.resolve(os.environ["HAB_URI"])
+version = cfg.aliases["houdinicore"]["distro"][1]
+```
 
 #### Complex Aliases
 

--- a/hab/parsers/flat_config.py
+++ b/hab/parsers/flat_config.py
@@ -100,10 +100,8 @@ class FlatConfig(Config):
                     continue
 
                 host_platform = utils.Platform.name()
-                # Ensure that we always have a dictionary for aliases
+                # Ensure the aliases are formatted and variables expanded
                 data = version.format_environment_value(aliases[i])
-                if not isinstance(data, dict):
-                    data = dict(cmd=data)
 
                 mods = self._alias_mods.get(alias_name, [])
                 if "environment" not in data and not mods:

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -441,10 +441,13 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
             self._dirname = self._filename.parent
 
     def format_environment_value(self, value, ext=None, platform=None):
-        """Apply standard formatting to environment variable values.
+        """Apply standard formatting to string values.
+
+         If passed a list, tuple, dict, recursively calls this function on them
+         converting any strings found. Any bool or int values are not modified.
 
         Args:
-            value (str): The string to format
+            value: The string to format.
             ext (str, optional): Language passed to ``hab.formatter.Formatter``
                 for special formatters. In most cases this should not be used.
             platform (str, optional): Convert path values from the current
@@ -463,6 +466,12 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
                 self.format_environment_value(v, ext=ext, platform=platform)
                 for v in value
             ]
+        elif isinstance(value, tuple):
+            # Format the individual items if a tuple of args is used.
+            return tuple(
+                self.format_environment_value(v, ext=ext, platform=platform)
+                for v in value
+            )
         elif isinstance(value, dict):
             # Format the values each dictionary pair
             return {

--- a/tests/distros/all_settings/0.1.0.dev1/invalid.hab.json
+++ b/tests/distros/all_settings/0.1.0.dev1/invalid.hab.json
@@ -1,0 +1,22 @@
+{
+    "name": "all_settings",
+    "version": "0.1.0.dev1",
+    "aliases": {
+        "windows": [
+            [
+                "maya",
+                {
+                    "cmd": "C:\\Program Files\\Autodesk\\Maya2020\\bin\\maya.exe",
+                    "distro": ["all_settings", "0.1.0"]
+                }
+            ],
+            [
+                "mayapy",
+                {
+                    "cmd": "C:\\Program Files\\Autodesk\\Maya2020\\bin\\mayapy.exe",
+                    "distro": ["all_settings", "0.1.0"]
+                }
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
This lets you look up version information for the alias the current hab configuration is using.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
