### PR TITLE
Improvements to cli plugin interface and support `python -m hab launch`

### DIFF
--- a/hab/cli.py
+++ b/hab/cli.py
@@ -721,11 +721,13 @@ def cli(*args, **kwargs):
         return _cli(*args, **kwargs)
     except Exception:
         click.echo(f"{Fore.RED}Hab encountered an error:{Fore.RESET}")
-        if _verbose_errors:
-            # In verbose mode show the full traceback
+        if _verbose_errors or sys.excepthook != sys.__excepthook__:
+            # If a plugin has replaced sys.excepthook it likely want's to handle
+            # how the traceback is handled.
+            # Ensure the full traceback is shown when in verbose mode.
             raise
 
-        # Print the traceback message without the stack trace.
+        # Otherwise print the traceback message without the stack trace.
         click.echo(traceback.format_exc(limit=0))
         return 1
 

--- a/hab/errors.py
+++ b/hab/errors.py
@@ -22,6 +22,24 @@ class MaxRedirectError(RequirementError):
     """The maximum number of redirects was reached without resolving successfully."""
 
 
+class InvalidAliasError(HabError):
+    """Raised the requested alias was not found.
+
+    Args:
+        alias (str): The requested alias name.
+        cfg (hab.parser.Config): The hab config used to launch the alias.
+        msg (str, optional): The error message. `str.format` is called on this
+            passing the kwargs `alias` and `uri`.
+    """
+
+    def __init__(self, alias, cfg, msg=None):
+        self.alias = alias
+        self.cfg = cfg
+        if msg is None:
+            msg = 'The alias "{alias}" is not found for URI "{uri}".'
+        super().__init__(msg.format(alias=alias, uri=cfg.uri))
+
+
 class InvalidRequirementError(RequirementError):
     """Raised if unable to resolve a given requirement."""
 

--- a/hab/parsers/config.py
+++ b/hab/parsers/config.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from .. import NotSet, utils
-from ..errors import HabError
+from ..errors import HabError, InvalidAliasError
 from .hab_base import HabBase
 from .meta import hab_property
 
@@ -71,7 +71,7 @@ class Config(HabBase):
         """
         # Construct the command line arguments to execute
         if alias_name not in self.aliases:
-            raise HabError(f'"{alias_name}" is not a valid alias name')
+            raise InvalidAliasError(alias_name, self)
         alias = self.aliases[alias_name]
 
         # Get the subprocess.Popen like class to use to launch the alias

--- a/hab/parsers/config.py
+++ b/hab/parsers/config.py
@@ -52,9 +52,9 @@ class Config(HabBase):
 
         Args:
             alias_name (str): The alias name to run.
-            args (list): The command to be run by subprocess. This should be a list
-                of each individual string argument. If a kwarg is being passed it
-                should be passed as two items. ['--key', 'value'].
+            args (list): Additional arguments for the command to be run by subprocess.
+                This should be a list of each individual string argument. If a kwarg
+                is being passed it should be passed as two items. ['--key', 'value'].
             blocking (bool or str, optional): Makes this method blocking by calling
                 Popen.communicate. If a str value is used, is included in the call.
                 The results of calling `proc.communicate` can be accessed from the

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -9,7 +9,12 @@ from jinja2 import Environment, FileSystemLoader
 from packaging.version import Version
 
 from .. import NotSet, utils
-from ..errors import DuplicateJsonError, HabError, ReservedVariableNameError
+from ..errors import (
+    DuplicateJsonError,
+    HabError,
+    InvalidAliasError,
+    ReservedVariableNameError,
+)
 from ..formatter import Formatter
 from ..site import MergeDict
 from ..solvers import Solver
@@ -809,7 +814,7 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
 
             # Get the cmd to launch, raising useful errors if invalid
             if launch not in self.aliases:
-                raise HabError(f'"{launch}" is not a valid alias name')
+                raise InvalidAliasError(launch, self)
             alias = self.aliases.get(launch, {})
 
             try:

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -8,7 +8,7 @@ import sys
 import pytest
 
 from hab import Resolver, Site, utils
-from hab.errors import HabError
+from hab.errors import HabError, InvalidAliasError
 
 
 class Topen(subprocess.Popen):
@@ -115,7 +115,10 @@ def test_pythonw(monkeypatch, resolver):
 
 def test_invalid_alias(resolver):
     cfg = resolver.resolve("app/aliased/mod")
-    with pytest.raises(HabError, match='"not-a-alias" is not a valid alias name'):
+    with pytest.raises(
+        InvalidAliasError,
+        match='The alias "not-a-alias" is not found for URI "app/aliased/mod".',
+    ):
         cfg.launch("not-a-alias")
 
     # Remove the "cmd" value to test an invalid configuration

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -291,7 +291,10 @@ def test_invalid_alias(uncached_resolver, tmpdir, ext):
 
     # Check that calling a bad alias name raises a useful error message
     cfg = uncached_resolver.resolve("not_set/child")
-    with pytest.raises(errors.HabError, match=r'"bad-alias" is not a valid alias name'):
+    with pytest.raises(
+        errors.InvalidAliasError,
+        match=r'The alias "bad-alias" is not found for URI "not_set/child".',
+    ):
         cfg.write_script(str(tmpdir), launch="bad-alias", **kwargs)
 
     # Remove the "cmd" value to test an invalid configuration


### PR DESCRIPTION
- Fix inability to use `python -m hab launch`
- Fix issue where excepthook overrides only got called by the hab cli if already in verbose mode.
- Allow a click command to disable the prompt feature of UriArgument. This improves the [hab_gui](https://github.com/blurstudio/hab-gui/pull/20) cli.
- Add a custom exception class for invalid alias names

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->