### PR TITLE
Fix bug if using `hab env -` introduced by last release

### DIFF
--- a/hab/cli.py
+++ b/hab/cli.py
@@ -252,7 +252,9 @@ class SharedSettings(object):
             # Otherwise just process the uri like normal
             cfg = self.resolver.resolve(uri)
 
-        msg = f"Launching alias: {launch} {' '.join(args)} for URI: {cfg.uri}"
+        if launch:
+            _args = f" {' '.join(args)}" if args else ""
+            launch_msg = f"Launching alias: {launch}{_args} for URI: {cfg.uri}"
         if self.script_dir:
             # Hab was called using the shell scripts, use them to launch the alias
             # using the same system as `hab launch - alias_name`. This allows the
@@ -260,7 +262,7 @@ class SharedSettings(object):
             # is launched ensuring that if something kills python processes it won't
             # affect the launched alias or any host shells
             if launch:
-                logger.info(f"{msg} using shell.")
+                logger.info(f"{launch_msg} using shell.")
             cfg.write_script(
                 self.script_dir,
                 self.script_ext,
@@ -285,7 +287,7 @@ class SharedSettings(object):
                 kwargs["stderr"] = None
                 kwargs["stdout"] = None
 
-            logger.info(f"{msg} as subprocess.")
+            logger.info(f"{launch_msg} as subprocess.")
             proc = cfg.launch(launch, args, blocking=blocking, **kwargs)
             if blocking:
                 sys.exit(proc.returncode)


### PR DESCRIPTION
Args was None when not using the launch sub-command this broke the logging message even though it wasn't being used.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
