### PR TITLE
Add Optional Distro for config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         args: [--min-py3-version=3.6]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-json
         exclude: '^tests/invalid.json'

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -583,6 +583,8 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
             self.environment_config = data.get("environment", NotSet)
         if self.min_verbosity is NotSet:
             self.min_verbosity = data.get("min_verbosity", NotSet)
+        if self.optional_distros is NotSet:
+            self.optional_distros = data.get("optional_distros", NotSet)
 
         if self.context is NotSet:
             # TODO: make these use override methods
@@ -634,6 +636,20 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
     @name.setter
     def name(self, name):
         self.frozen_data["name"] = name
+
+    @hab_property(verbosity=1)
+    def optional_distros(self):
+        """Information about distros chosen to be optionally enabled for a config.
+
+        The key is the distro including version specifier text. The value is a 2
+        item list containing a description to shown next to the key and a bool
+        indicating that it should be enabled by default when used.
+        """
+        return self.frozen_data.get("optional_distros", NotSet)
+
+    @optional_distros.setter
+    def optional_distros(self, value):
+        self.frozen_data["optional_distros"] = value
 
     def reduced(self, resolver=None, uri=None):
         """Returns a new instance with the final settings applied respecting inheritance"""

--- a/hab/resolver.py
+++ b/hab/resolver.py
@@ -1,5 +1,6 @@
 # __all__ = ["Resolver"]
 
+import copy
 import logging
 
 import anytree
@@ -57,6 +58,9 @@ class Resolver(object):
             self.forced_requirements = Solver.simplify_requirements(forced_requirements)
         else:
             self.forced_requirements = {}
+        # Store a copy of the original forced_requirements so plugins can restore
+        # the original value if they need to temporarily modify it.
+        self.__forced_requirements__ = copy.deepcopy(self.forced_requirements)
 
         logger.debug("config_paths: {}".format(self.config_paths))
         logger.debug("distro_paths: {}".format(self.distro_paths))

--- a/tests/configs/optional/optional.json
+++ b/tests/configs/optional/optional.json
@@ -1,0 +1,16 @@
+{
+    "name": "optional",
+    "context": [],
+    "inherits": false,
+    "distros": [
+        "the_dcc"
+    ],
+    "optional_distros": {
+        "maya2024": ["Adds new aliases"],
+        "the_dcc==1.0": ["Specific dcc version. Only choose one at a time."],
+        "the_dcc==1.2": ["Specific dcc version. Only choose one at a time."],
+        "the_dcc_plugin_a": ["Load an optional plugin by default", true],
+        "the_dcc_plugin_a==0.9": ["Force a specific version of this optinal plugin"],
+        "the_dcc_plugin_b": ["Only have a few licenses for this plugin, so opt into loading it"]
+    }
+}

--- a/tests/configs/optional/optional_child.json
+++ b/tests/configs/optional/optional_child.json
@@ -1,0 +1,11 @@
+{
+    "name": "child",
+    "context": ["optional"],
+    "inherits": false,
+    "distros": [
+        "the_dcc"
+    ],
+    "optional_distros": {
+        "the_dcc_plugin_e": ["Different optional dependencies for a child URI.", true]
+    }
+}

--- a/tests/distros/the_dcc/1.0/.hab.json
+++ b/tests/distros/the_dcc/1.0/.hab.json
@@ -8,7 +8,8 @@
     ],
     "aliases": {
         "windows": [
-            ["dcc", "{relative_root}\\the_dcc.exe"]
+            ["dcc", "{relative_root}\\the_dcc.exe"],
+            ["dcc1.0", "{relative_root}\\the_dcc.exe"]
         ]
     }
 }

--- a/tests/distros/the_dcc/1.1/.hab.json
+++ b/tests/distros/the_dcc/1.1/.hab.json
@@ -6,7 +6,8 @@
     ],
     "aliases": {
         "windows": [
-            ["dcc", "{relative_root}\\the_dcc.exe"]
+            ["dcc", "{relative_root}\\the_dcc.exe"],
+            ["dcc1.1", "{relative_root}\\the_dcc.exe"]
         ]
     }
 }

--- a/tests/distros/the_dcc/1.2/.hab.json
+++ b/tests/distros/the_dcc/1.2/.hab.json
@@ -8,10 +8,12 @@
     ],
     "aliases": {
         "linux": [
-            ["dcc", "{relative_root}//the_dcc"]
+            ["dcc", "{relative_root}//the_dcc"],
+            ["dcc1.2", "{relative_root}//the_dcc"]
         ],
         "windows": [
-            ["dcc", "{relative_root}\\the_dcc.exe"]
+            ["dcc", "{relative_root}\\the_dcc.exe"],
+            ["dcc1.2", "{relative_root}\\the_dcc.exe"]
         ]
     }
 }

--- a/tests/frozen.json
+++ b/tests/frozen.json
@@ -5,10 +5,24 @@
   "name": "distros",
   "aliases": {
     "windows": {
-      "dcc": "TEST_DIR_NAME\\the_dcc.exe"
+      "dcc": {
+        "cmd": "TEST_DIR_NAME\\the_dcc.exe",
+        "distro": ["the_dcc", "1.2"]
+      },
+      "dcc1.2": {
+        "cmd": "TEST_DIR_NAME\\the_dcc.exe",
+        "distro": ["the_dcc", "1.2"]
+      }
     },
     "linux": {
-      "dcc": "TEST_DIR_NAME//the_dcc"
+      "dcc": {
+        "cmd": "TEST_DIR_NAME//the_dcc",
+        "distro": ["the_dcc", "1.2"]
+      },
+      "dcc1.2": {
+        "cmd": "TEST_DIR_NAME//the_dcc",
+        "distro": ["the_dcc", "1.2"]
+      }
     }
   },
   "versions": [

--- a/tests/site_main_check.habcache
+++ b/tests/site_main_check.habcache
@@ -366,6 +366,51 @@
                 },
                 "inherits": false
             },
+            "{config-root}/configs/optional/optional.json": {
+                "name": "optional",
+                "context": [],
+                "inherits": false,
+                "distros": [
+                    "the_dcc"
+                ],
+                "optional_distros": {
+                    "maya2024": [
+                        "Adds new aliases"
+                    ],
+                    "the_dcc==1.0": [
+                        "Specific dcc version. Only choose one at a time."
+                    ],
+                    "the_dcc==1.2": [
+                        "Specific dcc version. Only choose one at a time."
+                    ],
+                    "the_dcc_plugin_a": [
+                        "Load an optional plugin by default",
+                        true
+                    ],
+                    "the_dcc_plugin_a==0.9": [
+                        "Force a specific version of this optinal plugin"
+                    ],
+                    "the_dcc_plugin_b": [
+                        "Only have a few licenses for this plugin, so opt into loading it"
+                    ]
+                }
+            },
+            "{config-root}/configs/optional/optional_child.json": {
+                "name": "child",
+                "context": [
+                    "optional"
+                ],
+                "inherits": false,
+                "distros": [
+                    "the_dcc"
+                ],
+                "optional_distros": {
+                    "the_dcc_plugin_e": [
+                        "Different optional dependencies for a child URI.",
+                        true
+                    ]
+                }
+            },
             "{config-root}/configs/place-holder/place-holder_child.json": {
                 "name": "child",
                 "context": [
@@ -1372,6 +1417,10 @@
                         [
                             "dcc",
                             "{relative_root}\\the_dcc.exe"
+                        ],
+                        [
+                            "dcc1.0",
+                            "{relative_root}\\the_dcc.exe"
                         ]
                     ]
                 },
@@ -1387,6 +1436,10 @@
                     "windows": [
                         [
                             "dcc",
+                            "{relative_root}\\the_dcc.exe"
+                        ],
+                        [
+                            "dcc1.1",
                             "{relative_root}\\the_dcc.exe"
                         ]
                     ]
@@ -1406,11 +1459,19 @@
                         [
                             "dcc",
                             "{relative_root}//the_dcc"
+                        ],
+                        [
+                            "dcc1.2",
+                            "{relative_root}//the_dcc"
                         ]
                     ],
                     "windows": [
                         [
                             "dcc",
+                            "{relative_root}\\the_dcc.exe"
+                        ],
+                        [
+                            "dcc1.2",
                             "{relative_root}\\the_dcc.exe"
                         ]
                     ]

--- a/tests/test_freeze.py
+++ b/tests/test_freeze.py
@@ -67,10 +67,20 @@ def test_freeze(monkeypatch, config_root, platform, pathsep):
     # Resolve the URI for frozen testing
     cfg = resolver.resolve("not_set/distros")
 
-    # Ensure consistent testing across platforms. cfg has the current os's
-    # file paths instead of what is stored in frozen.json
-    cfg.frozen_data["aliases"]["linux"]["dcc"] = "TEST_DIR_NAME//the_dcc"
-    cfg.frozen_data["aliases"]["windows"]["dcc"] = "TEST_DIR_NAME\\the_dcc.exe"
+    for alias in ("dcc", "dcc1.2"):
+        # Ensure consistent testing across platforms. cfg has the current os's
+        # file paths instead of what is stored in frozen.json
+        cfg.frozen_data["aliases"]["linux"][alias]["cmd"] = "TEST_DIR_NAME//the_dcc"
+        cfg.frozen_data["aliases"]["windows"][alias][
+            "cmd"
+        ] = "TEST_DIR_NAME\\the_dcc.exe"
+
+        # For ease of testing we also need to convert the distro tuple to a list
+        # that way it matches the json data stored in frozen.json
+        as_list = list(cfg.frozen_data["aliases"]["linux"][alias]["distro"])
+        cfg.frozen_data["aliases"]["linux"][alias]["distro"] = as_list
+        as_list = list(cfg.frozen_data["aliases"]["windows"][alias]["distro"])
+        cfg.frozen_data["aliases"]["windows"][alias]["distro"] = as_list
 
     # Ensure the HAB_URI environment variable is defined on the FlatConfig object
     # When checking the return from `cfg.freeze()` below HAB_URI is removed to

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -293,6 +293,7 @@ def test_metaclass():
             "filename",
             "min_verbosity",
             "name",
+            "optional_distros",
             "variables",
             "version",
         ]
@@ -308,6 +309,7 @@ def test_metaclass():
             "min_verbosity",
             "inherits",
             "name",
+            "optional_distros",
             "uri",
             "variables",
         ]
@@ -326,7 +328,11 @@ class TestDump:
         # Build the test data so we can generate the output to check
         # Note: using `repr([u"` so this test passes in python 2 and 3
         pre = ["name:  child", "uri:  not_set/child"]
-        post = ["inherits:  True", "min_verbosity:  NotSet"]
+        post = [
+            "inherits:  True",
+            "min_verbosity:  NotSet",
+            "optional_distros:  NotSet",
+        ]
         env = [
             "environment:  FMT_FOR_OS:  a{;}b;c:{PATH!e}{;}d",
             "              TEST:  case",
@@ -423,7 +429,12 @@ class TestDump:
         for verbosity in range(3):
             result = cfg.dump(verbosity=verbosity, color=False)
             assert "aliases" not in result
-            assert "distros:" not in result
+            assert " distros:" not in result
+            if not verbosity:
+                # This is shown for v1 or higher
+                assert "optional_distros:" not in result
+            else:
+                assert "optional_distros:" in result
 
 
 def test_environment(resolver):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from collections import OrderedDict
 from pathlib import Path
 
@@ -533,6 +534,22 @@ def test_forced_requirements(resolver, helpers, forced, check, check_versions):
     )
     resolved = resolver_forced.resolve_requirements(requirements)
     helpers.assert_requirements_equal(resolved, check)
+    if forced is None:
+        assert resolver_forced.__forced_requirements__ == {}
+    else:
+        assert resolver_forced.__forced_requirements__.keys() == forced.keys()
+
+        # Ensure this is a deepcopy of forced and ensure the values are equal
+        assert resolver_forced.__forced_requirements__ is not forced
+        for k, v in resolver_forced.__forced_requirements__.items():
+            if sys.version_info.minor == 6:
+                # NOTE: packaging>22.0 doesn't support equal checks for Requirement
+                # objects. Python 3.6 only has a 21 release, so we have to compare str
+                # TODO: Once we drop py3.6 support drop this if statement
+                assert str(forced[k]) == str(v)
+            else:
+                assert forced[k] == v
+            assert forced[k] is not v
 
     # Check that forced_requirements work if the config defines zero distros
     cfg = resolver_forced.resolve("not_set/no_distros")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -133,6 +133,8 @@ class TestDumpForest:
         "  not_set/no_distros",
         "  not_set/no_env",
         "  not_set/os",
+        "optional",
+        "  optional/child",
         "place-holder",
         "  place-holder/child",
         "  place-holder/inherits",


### PR DESCRIPTION
This adds a way to store additional suggested distros for a given URI config. These can be passed to the forced requirement system. This allows the [hab-gui](https://github.com/blurstudio/hab-gui/pull/21) to easily suggest these distros to users and let them enable them.

Optional distros may be required because enabling them would consume a software license that don't have enough to always use. It can also be useful for adding features that only specific users might want.

- Optional distros support version requirements so you can pin them.
- You can specify a description to describe to the user when to use the requirement.
- You can specify if it should be enabled by default(This is ignored by the hab cli, but [other plugins](https://github.com/blurstudio/hab-gui/pull/21) can use it.)

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
