### PR TITLE
Formatter now handles un-set environment variables

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 

--- a/.github/workflows/python-static-analysis-and-test.yml
+++ b/.github/workflows/python-static-analysis-and-test.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           # NOTE: Currently running this with python 3.12 causes
           # flake8 false-positives on lines with f-strings E226,E231,E241,E702
@@ -66,10 +66,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -83,10 +83,11 @@ jobs:
           tox -e begin,py-${{ matrix.json_ver }}
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.os }}-${{ matrix.python }}-${{ matrix.json_ver }}
           path: .coverage.*
+          include-hidden-files: true
           retention-days: 1
 
   coverage:
@@ -102,10 +103,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
@@ -120,9 +121,10 @@ jobs:
           tox -e begin
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: coverage
+          pattern: coverage-*
+          merge-multiple: true
 
       # Tox runs `coverage combine` and `coverage xml`
       - name: Combine coverage and report
@@ -139,7 +141,7 @@ jobs:
           # python -m coverage report --fail-under=100
 
       - name: Upload HTML report if check failed.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-report
           path: htmlcov
@@ -163,12 +165,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
@@ -182,7 +184,7 @@ jobs:
           python -m build --wheel --sdist
 
       - name: Upload packages.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pip-packages
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 build/
 coverage.xml
 dist/
+docs/
 htmlcov/
 venv/
 .venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 ci:
   autoupdate_schedule: quarterly
-  skip: [black, flake8]
+  skip: [black, flake8, setup-cfg-fmt]
 
 repos:
 

--- a/README.md
+++ b/README.md
@@ -880,7 +880,8 @@ with these extra features:
 * `{ANYTHING!e}`: `!e` is a special conversion flag for Environment variables. This will
 be replaced with the correct shell environment variable. For bash it becomes `$ANYTHING`,
 in power shell `$env:ANYTHING`, and in command prompt `%ANYTHING%`. `ANYTHING` is the name
-of the environment variable.
+of the environment variable. In some cases hab will expand these into the current
+environment variable if set, if the env var is not set the shell env variable will be used.
 
 #### Hab specific variables
 

--- a/hab/formatter.py
+++ b/hab/formatter.py
@@ -7,18 +7,27 @@ from . import utils
 class Formatter(string.Formatter):
     """A extended string formatter class to parse habitat configurations.
 
-    Adds support for the "!e" conversion flag. This will fill in the key as a properly
-    formatted environment variable specifier. For example ''{PATH!e}'' will be converted
-    to ``$PATH`` for the sh language, and ``%env:PATH`` for the ps language. You can
-    convert "!e" to "!s" by setting expand to True. This simulates `os.path.expandvars`.
+    Adds support for the ``!e`` `conversion field`_. This will fill in the key as a
+    properly formatted environment variable specifier. For example ``{PATH!e}`` will
+    be converted to ``$PATH`` for the sh language, and ``%env:PATH`` for the ps language.
+
+    By setting expand to True the ``!e`` conversion field will be filled in with the
+    environment variable for that key if the env variable is set. Otherwise it will
+    fall back the environment variable specifier.
 
     This also converts ``{;}`` to the language specific path separator for environment
     variables. On linux this is ``:`` on windows(even in bash) this is ``;``.
 
-    You need to specify the desired language when initializing this class. This can be
-    one of the supported language keys in ''Formatter.shell_formats'', or you can pass
-    a file extension supported by `Formatter.language_from_ext`. If you pass None, it
-    will preserve the formatting markers so it can be converted later.
+    Parameters:
+        language: Specify the shell language to use when converting ``!e``. See
+            :py:const:`Formatter.shell_formats` and :py:meth:`Formatter.language_from_ext`.
+            for supported values. If you pass None, it will preserve the
+            formatting markers so it can be converted later.
+        expand(bool, optional): Should the ``!e`` conversion insert the shell
+            environment variable specifier or the value of the env var?
+
+    .. _conversion field:
+       https://docs.python.org/3/library/string.html#grammar-token-format-string-conversion
     """
 
     shell_formats = {
@@ -50,28 +59,35 @@ class Formatter(string.Formatter):
             ";": "{;}",
         },
     }
+    """Information on how to generate shell specific environment variable references
+    and the character to use for pathsep. For each shell ``env_var`` is a format
+    string that accepts the env var name. ``;`` is the path separator to use.
+    """
 
     def __init__(self, language, expand=False):
         super().__init__()
         self.language = self.language_from_ext(language)
-        self.current_field_name = None
         self.expand = expand
 
-    def convert_field(self, value, conversion):
-        if conversion == "e":
-            # Expand the env var to the real string value simulating `os.path.expandvars`
-            if self.expand:
-                return super().convert_field(value, "s")
-
-            # Otherwise insert the correct shell script env var reference
-            return self.shell_formats[self.language]["env_var"].format(
-                self.current_field_name
-            )
-
-        return super().convert_field(value, conversion)
-
     def get_field(self, field_name, args, kwargs):
-        self.current_field_name = field_name
+        """Returns the object to be inserted for the given field_name.
+
+        If kwargs doesn't contain ``field_name`` but ``field_name`` is in the
+        environment variables, the stored value is returned. This also returns
+        the pathsep for the ``;`` field_name. Otherwise works the same as
+        the standard `string.Formatter`_.
+
+        .. _`string.Formatter`:
+           https://docs.python.org/3/library/string.html#string.Formatter.get_field
+        """
+        # If a field_name was not provided, use the value stored in os.environ
+        if field_name not in kwargs and field_name in os.environ:
+            return os.getenv(field_name), field_name
+        # Process the pathsep character
+        if field_name == ";":
+            value = self.shell_formats[self.language][";"]
+            return value, field_name
+
         ret = super().get_field(field_name, args, kwargs)
         return ret
 
@@ -97,16 +113,19 @@ class Formatter(string.Formatter):
                 return "sh"
         return ext
 
-    def merge_kwargs(self, kwargs):
-        """Merge the provided kwargs on top of the current language's shell_formats
-        dict. This makes it so the default format options are added by default, but
-        still allows us to override them if required
-        """
-        ret = dict(self.shell_formats[self.language], **kwargs)
-        ret = dict(os.environ, **ret)
-        return ret
+    def parse(self, txt):
+        for literal_text, field_name, format_spec, conversion in super().parse(txt):
+            # Non-hab specific operation, just use the super value unchanged
+            if conversion != "e":
+                yield (literal_text, field_name, format_spec, conversion)
+                continue
 
-    def vformat(self, format_string, args, kwargs):
-        kwargs = self.merge_kwargs(kwargs)
-        ret = super().vformat(format_string, args, kwargs)
-        return ret
+            elif self.expand and field_name in os.environ:
+                # Expand the env var to the env var value. Later `get_field`
+                # will update kwargs with the existing env var value
+                yield (literal_text, field_name, format_spec, "s")
+                continue
+
+            # Convert this !e conversion to the shell specific env var specifier
+            value = self.shell_formats[self.language]["env_var"].format(field_name)
+            yield (literal_text + value, None, None, None)


### PR DESCRIPTION
Addresses https://github.com/blurstudio/hab-gui/issues/24. Refactor the hab Formatter class so the parse method converts `!e` to literal text or a standard `!s` conversion. Also uses the `get_field` method to extract env var's on demand instead of adding all env vars to the provided kwargs.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
