### PR TITLE
Add `Platform.normalize_path` to ensure standard path strings

### DIFF
--- a/hab/site.py
+++ b/hab/site.py
@@ -244,6 +244,8 @@ class Site(UserDict):
             path = PureWindowsPath(path)
         else:
             path = PurePosixPath(path)
+        # Ensure any path normalization is applied
+        path = utils.Platform.normalize_path(path)
 
         platform = utils.Platform.name()
         mappings = self.get("platform_path_maps", {})

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -469,8 +469,8 @@ class BasePlatform(ABC):
         a list containing Path objects.
         """
         if isinstance(paths, str):
-            return [Path(p) for p in paths.split(cls.pathsep())]
-        return [Path(p) for p in paths]
+            return [cls.normalize_path(Path(p)) for p in paths.split(cls.pathsep())]
+        return [cls.normalize_path(Path(p)) for p in paths]
 
     @staticmethod
     def get_platform(name=None):
@@ -490,6 +490,11 @@ class BasePlatform(ABC):
     def name(cls):
         """The hab name for this platform."""
         return cls._name
+
+    @classmethod
+    def normalize_path(cls, path):
+        """Returns the provided `pathlib.Path` with any normalization required."""
+        return path
 
     @classmethod
     def path_split(cls, path, pathsep=None):
@@ -569,6 +574,18 @@ class WinPlatform(BasePlatform):
         else:
             paths = [str(p) for p in paths]
         return cls.pathsep(ext=ext, key=key).join(paths)
+
+    @classmethod
+    def normalize_path(cls, path):
+        """Returns the provided `pathlib.Path` with any normalization required.
+
+        This ensures that the drive letter is resolved consistently to uppercase.
+        """
+        if not path.is_absolute():
+            return path
+        parts = path.parts
+        cls = type(path)
+        return cls(parts[0].upper()).joinpath(*parts[1:])
 
     @classmethod
     def pathsep(cls, ext=None, key=None):

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -443,6 +443,11 @@ class TestPlatformPathMap:
         out = site.platform_path_key(r"c:\host\root\extra", platform="windows")
         assert out.as_posix() == "{host-root}/extra"
 
+        # Test that normalize_path was called for unmodified paths and
+        # capitalized the drive letter
+        out = site.platform_path_key(r"z:\root\path", platform="windows")
+        assert out.as_posix() == r"Z:/root/path"
+
     def test_unset_variables(self, config_root):
         """Don't modify variables that are not specified in platform_path_map"""
         site = Site([config_root / "site_main.json"])


### PR DESCRIPTION
`WinPlatform.normalize_path` ensures that drive letters are always capitalized.

This fixes issues with windows drive letters not being consistently saved in the habcache. When platform_path_map is not used on a habcache'd path the cache would not find and load the cached value.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
