### PR TITLE
Add hab install to download and install required distros

### DIFF
--- a/.github/workflows/python-static-analysis-and-test.yml
+++ b/.github/workflows/python-static-analysis-and-test.yml
@@ -52,15 +52,6 @@ jobs:
         json_ver: ['json', 'json5']
         os: ['ubuntu-latest', 'windows-latest']
         python: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        # Works around the depreciation of python 3.6 for ubuntu
-        # https://github.com/actions/setup-python/issues/544
-        include:
-          - json_ver: 'json'
-            os: 'ubuntu-20.04'
-            python: '3.6'
-          - json_ver: 'json5'
-            os: 'ubuntu-20.04'
-            python: '3.6'
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/python-static-analysis-and-test.yml
+++ b/.github/workflows/python-static-analysis-and-test.yml
@@ -49,9 +49,21 @@ jobs:
     strategy:
       matrix:
         # Test if using native json or pyjson5 for json parsing
-        json_ver: ['json', 'json5']
+        pkg_mods: ['json', 'json5', 's3']
         os: ['ubuntu-latest', 'windows-latest']
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11']
+        # Works around the depreciation of python 3.6 for ubuntu
+        # https://github.com/actions/setup-python/issues/544
+        include:
+          - pkg_mods: 'json'
+            os: 'ubuntu-22.04'
+            python: '3.7'
+          - pkg_mods: 'json5'
+            os: 'ubuntu-22.04'
+            python: '3.7'
+          - pkg_mods: 's3'
+            os: 'ubuntu-22.04'
+            python: '3.7'
 
     runs-on: ${{ matrix.os }}
 
@@ -71,12 +83,12 @@ jobs:
 
       - name: Run Tox
         run: |
-          tox -e begin,py-${{ matrix.json_ver }}
+          tox -e begin,py-${{ matrix.pkg_mods }}
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.os }}-${{ matrix.python }}-${{ matrix.json_ver }}
+          name: coverage-${{ matrix.os }}-${{ matrix.python }}-${{ matrix.pkg_mods }}
           path: .coverage.*
           include-hidden-files: true
           retention-days: 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     rev: v2.5.0
     hooks:
     -   id: setup-cfg-fmt
-        args: [--min-py3-version=3.6]
+        args: [--min-py3-version=3.7]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/README.md
+++ b/README.md
@@ -1367,7 +1367,7 @@ most part you can control the output using the `hab -v ...` verbosity option.
 However if you need more fine grained control you can create a `.hab_logging_prefs.json`
 file next to your user [user prefs](#user-prefs) file. The cli also supports passing
 the path to a configuration file using `hab --logging-config [path/to/file.json]`
-that is used instead of the default file if pased.
+that is used instead of the default file if passed.
 
 # Caveats
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ home directory on other platforms.
 
 ## Installing
 
-Hab is installed using pip. It requires python 3.6 or above. It's recommended
+Hab is installed using pip. It requires python 3.7 or above. It's recommended
 that you add the path to your python's bin or Scripts folder to the `PATH`
 environment variable so you can simply run the `hab` command.
 

--- a/README.md
+++ b/README.md
@@ -1451,6 +1451,9 @@ hab in batch mode.
 Approximate time generated using `time cmd.exe /c  "hab -h"` in git bash after
 omitting the `%py_exe% -m ...` call.
 
+You can also set the `%TMP%` environment variable to a unique folder, but this
+is more of a fix for scripted or unittest workflows.
+
 # Glosary
 
 * **activate:** Update the current process(shell) for a given configuration. Name taken

--- a/hab/__init__.py
+++ b/hab/__init__.py
@@ -1,10 +1,10 @@
-__all__ = ["__version__", "NotSet", "Resolver", "Site"]
+__all__ = ["__version__", "DistroMode", "NotSet", "Resolver", "Site"]
 
 from .utils import NotSet
 
 # Note: Future imports depend on NotSet so it must be imported first
 # isort: split
 
-from .resolver import Resolver
+from .resolver import DistroMode, Resolver
 from .site import Site
 from .version import version as __version__

--- a/hab/cache.py
+++ b/hab/cache.py
@@ -111,6 +111,7 @@ class Cache:
         the provided site file. Use this method any time changes are made that
         hab needs to be aware of. Caching is enabled by the existence of this file.
         """
+        from .distro_finders.distro_finder import DistroFinder
         from .site import Site
 
         # Indicate the version specification this habcache file conforms to.
@@ -125,6 +126,9 @@ class Cache:
             glob_str, cls = stats
             # Process each glob dir defined for this site
             for dirname in temp_site.get(key, []):
+                # Caching is only supported for direct file paths
+                if isinstance(dirname, DistroFinder):
+                    dirname = dirname.root
                 cfg_paths = output.setdefault(key, {}).setdefault(
                     platform_path_key(dirname).as_posix(), {}
                 )
@@ -180,7 +184,7 @@ class Cache:
                 logger.debug(f"Using glob for {name} dir: {dirname}")
                 # Fallback to globing the file system
                 if glob_str:
-                    paths = sorted(glob.glob(str(dirname / glob_str)))
+                    paths = utils.glob_path(dirname / glob_str)
                 else:
                     paths = []
             if not include_path:

--- a/hab/cache.py
+++ b/hab/cache.py
@@ -152,9 +152,23 @@ class Cache:
         """Yields path information stored in the cache falling back to glob if
         not cached.
 
+        Args:
+            name (str): The name of the cache being iterated. Often "config_paths"
+                or "distro_paths".
+            paths (list): A list of `pathlib.Path` paths to process. If this includes
+                glob paths they will be processed.
+            cache (dict): The cached data used if possible for each path. If a
+                path isn't in the cache, then will glob the path.
+            glob_str (str, optional): Added to each path if passed and a glob
+                is required. Ignored if the path is cached.
+            include_path (bool, optional): Controls how many items are yielded.
+                If True then each cached or globed path is yielded. Otherwise only
+                each path(dirname) is yielded and path is always None.
+
         Yields:
-            dirname: Each path stored in paths.
-            path
+            dirname: Each path passed by paths.
+            path: The path to a given resource for this dirname.
+            cached: If the path was stored in a cache or required using glob.
         """
         for dirname in paths:
             dn_posix = dirname.as_posix()

--- a/hab/distro_finders/cloud_zip.py
+++ b/hab/distro_finders/cloud_zip.py
@@ -1,0 +1,132 @@
+import logging
+import pathlib
+import time
+import zipfile
+from abc import ABCMeta, abstractmethod
+
+import remotezip
+from cloudpathlib import CloudPath
+
+from .df_zip import DistroFinderZip
+
+logger = logging.getLogger(__name__)
+
+
+class HabRemoteZip(remotezip.RemoteZip):
+    """`remotezip.RemoteZip` that doesn't call `close()` when exiting a with context.
+
+    Opening a new RemoteZip instance is slow and changes depending on the size
+    of the .zip file. Cloud based workflow doesn't need to close the file pointer
+    like you need to when working on a local file.
+    """
+
+    def __exit__(self, type, value, traceback):
+        pass
+
+
+class DistroFinderCloudZip(DistroFinderZip, metaclass=ABCMeta):
+    """Works with zipped distros stored remotely in Amazon S3 buckets.
+
+    Working with zipped distros extracting the `hab_filename` information from
+    inside the .zip file. This is useful when you have direct access to the .zip
+    file.
+
+    For `path`, this class uses a .zip `member path`. A member path is the absolute
+    path to the .zip joined with the member path of files contained inside the .zip
+    file. So if the archive file path is `c:/temp/dist_a_v0.1.zip` and the member is
+    `hab_filename`, then the member_path would be `c:/temp/dist_a_v0.1.zip/.hab.json`.
+
+    Note:
+        This class should only be used to install distros in the hab download system.
+
+    This expects one file to exist with a specific naming convention:
+        - `{distro}_v{version}.zip` contains the entire contents of the distro.
+          This should also contain the top level file `hab_filename`. When the distro
+          is installed and using hab normally this file will be used. The `hab_filename`
+          file's contents are extracted from the zip file and used to initialize the
+          `DistroVersion` returned by `self.distro` without being written to disk.
+    """
+
+    def __init__(self, root, site=None, safe=False, client=None):
+        # Only define client if it was passed, otherwise create it lazily.
+        if client:
+            self.client = client
+        super().__init__(root, site=site, safe=safe)
+        self._archives = {}
+
+    def as_posix(self):
+        """Returns the root path as a posix style string."""
+        if isinstance(self.root, CloudPath):
+            # CloudPath doesn't need as_posix
+            return str(self.root)
+        return super().as_posix()
+
+    def cast_path(self, path):
+        """Return path cast to the `pathlib.Path` like class preferred by this class."""
+        return CloudPath(path, client=self.client)
+
+    @property
+    @abstractmethod
+    def client(self):
+        """A `cloudpathlib.client.Client` used to create `CloudPath` instances."""
+
+    @client.setter
+    @abstractmethod
+    def client(self, client):
+        """A `cloudpathlib.client.Client` used to create `CloudPath` instances."""
+
+    @abstractmethod
+    def credentials(self):
+        """Returns the credentials needed for requests to connect to the cloud resource.
+
+        Generates these credentials using the client object.
+        """
+
+    def archive(self, zip_path, partial=True):
+        """Returns a `zipfile.Zipfile` like instance for zip_path.
+
+        Args:
+            zip_path (cloudpathlib.CloudPath): The path to the zip file to open.
+            partial (bool, optional): If True then you only need access to a small
+                part of the archive. If True then `HabRemoteZip` will be used
+                to only download specific files from the remote archive without
+                caching them to disk. If False then remote archives will be fully
+                downloaded to disk(using caching) before returning the open archive.
+        """
+        if not partial or isinstance(zip_path, pathlib.PurePath):
+            logger.debug(f"Using CloudPath to open(downloading if needed) {zip_path}.")
+            archive = zipfile.ZipFile(zip_path)
+            archive.filename = zip_path
+            return archive
+
+        # Creating a RemoteZip instance is very slow compared to local file access.
+        # Reuse existing objects if already created.
+        if zip_path in self._archives:
+            logger.debug(f"Reusing cloud .zip resource: {zip_path}")
+            return self._archives[zip_path]
+
+        logger.debug(f"Connecting to cloud .zip resource: {zip_path}")
+        s = time.time()
+        auth, headers = self.credentials()
+
+        archive = HabRemoteZip(zip_path.as_url(), auth=auth, headers=headers)
+        archive.filename = zip_path
+        e = time.time()
+        logger.info(f"Connected to cloud .zip resource: {zip_path}, took: {e - s}")
+        self._archives[zip_path] = archive
+        return archive
+
+    def clear_cache(self, persistent=False):
+        """Clear cached data in memory. If `persistent` is True then also remove
+        cache data from disk if it exists.
+        """
+        super().clear_cache(persistent=persistent)
+
+        # Ensure all cached archives are closed before clearing the cache.
+        for archive in self._archives.values():
+            archive.close()
+
+        self._archives = {}
+        if persistent:
+            # Clear downloaded temp files
+            self.client.clear_cache()

--- a/hab/distro_finders/df_zip.py
+++ b/hab/distro_finders/df_zip.py
@@ -1,0 +1,165 @@
+import logging
+
+from .. import utils
+from .zip_sidecar import DistroFinderZipSidecar
+
+logger = logging.getLogger(__name__)
+
+
+class DistroFinderZip(DistroFinderZipSidecar):
+    """Working with zipped distros extracting the `hab_filename` information from
+    inside the .zip file. This is useful when you have direct access to the .zip
+    file.
+
+    For `path`, this class uses a .zip `member path`. A member path is the absolute
+    path to the .zip joined with the member path of files contained inside the .zip
+    file. So if the archive file path is `c:/temp/dist_a_v0.1.zip` and the member is
+    `hab_filename`, then the member_path would be `c:/temp/dist_a_v0.1.zip/.hab.json`.
+
+    Note:
+        This class should only be used to install distros in the hab download system.
+
+    This expects one file to exist with a specific naming convention:
+        - `{distro}_v{version}.zip` contains the entire contents of the distro.
+          This should also contain the top level file `hab_filename`. When the distro
+          is installed and using hab normally this file will be used. The `hab_filename`
+          file's contents are extracted from the zip file and used to initialize the
+          `DistroVersion` returned by `self.distro` without being written to disk.
+    """
+
+    def __init__(self, root, site=None, safe=True):
+        super().__init__(root, site=site)
+        self.glob_str = "*.zip"
+        self._cache = {}
+        self.safe = safe
+
+    def clear_cache(self, persistent=False):
+        """Clear cached data in memory. If `persistent` is True then also remove
+        cache data from disk if it exists.
+        """
+        self._cache = {}
+
+    def content(self, path):
+        """Returns the distro container for a given path as `pathlib.Path`.
+
+        For this class it returns the path to the .zip file. This .zip file
+        contains the contents of the distro and the actual `hab_filename` used
+        to create the distro.
+
+        Args:
+            path (pathlib.Path): The member path to the `hab_filename` file defining
+                the distro.
+        """
+        # If path is already a .zip file return it.
+        # Note: We can't concatenate this with `pathlib.Path.parents` so this has
+        # to be done separately from the for loop later
+        if path.suffix.lower() == ".zip":
+            return path
+
+        # Search for the right most .zip file extension and return that path if found
+        for parent in path.parents:
+            if parent.suffix.lower() == ".zip":
+                return parent
+
+        # Otherwise fall back to returning the path
+        return path
+
+    def content_member(self, path):
+        """Splits a member path into content and member.
+
+        Args:
+            path (os.PathLike): The member path to split.
+
+        Returns:
+            content(os.PathLike): Path to the .zip file.
+            member (str): Any remaining member path after the .zip file. If path
+                doesn't specify a member, then a empty string is returned.
+        """
+        content = self.content(path)
+        member = str(path.relative_to(content))
+        # Return a empty string instead of the relative dot
+        if member == ".":
+            member = ""
+        return content, member
+
+    def distro_path_info(self):
+        """Generator yielding distro info for each distro found by this distro finder.
+
+        Note:
+            This class doesn't use habcache features so cached will always be `False`.
+
+        Yields:
+            dirname: Will always be `None`. This class deals with only compressed
+                .zip files so there is not a parent directory to work with.
+            path: The member path to a given resource.
+            cached: Will always be `False`. The path is not stored in a .habcache
+                file so this data is not cached across processes.
+        """
+        for path in self.root.glob(self.glob_str):
+            member_path = path / self.hab_filename
+            if self.safe:
+                # Opening archives on cloud based systems is slow, this allows us
+                # to disable checking that the archive actually has a `hab_filename` file.
+                data = self.get_file_data(member_path)
+                # This should only return None if the archive doesn't contain member
+                if data is None:
+                    continue
+
+            yield None, member_path, False
+
+    def get_file_data(self, path):
+        """Return the data stored inside a member of a .zip file as bytes.
+
+        This is cached and will only open the .zip file to read the contents the
+        first time path is used for this instance.
+
+        Args:
+            path: The member path to a given resource. If the path points directly
+                to a .zip file then member is assumed to be `self.hab_filename`.
+        """
+        content, member = self.content_member(path)
+        if not member:
+            member = self.hab_filename
+            path = path / member
+            logger.debug(f'Implicitly added member "{member}" to path "{path}".')
+
+        if path in self._cache:
+            return self._cache[path]
+
+        with self.archive(content) as archive:
+            if member in archive.namelist():
+                data = archive.read(member)
+            else:
+                data = None
+            self._cache[path] = data
+
+        return self._cache[path]
+
+    def load_path(self, path):
+        """Returns a raw dictionary use to create a `DistroVersion` with version set.
+
+        Returns the actual contents of the .zip file's top level file `hab_filename`
+        without writing that data to disk. The return is passed to `DistroVersion.load`
+        as the data argument. This allows the `DistroFinder` class to directly use
+        the data contained inside the .zip archive.
+
+        The version property will always be set in the return. If not defined
+        in the `hab_filename` file's contents, its set to the return of `version_for_path`.
+
+        Args:
+            path (pathlib.Path): The member path to the `hab_filename` file inside
+                of the .zip file.
+
+        Raises:
+            KeyError: This method uses the cache populated by `distro_path_info`
+                and that method needs to be called before calling this. It is also
+                raised if the requested `path` is not defined in the distro.
+        """
+        logger.debug(f'Loading json: "{path}"')
+        data = self.get_file_data(path)
+        data = data.decode("utf-8")
+        data = utils.loads_json(data, source=path)
+        # Pull the version from the sidecar filename if its not explicitly set
+        if "version" not in data:
+            _, data["version"] = self.version_for_path(path)
+        return data

--- a/hab/distro_finders/distro_finder.py
+++ b/hab/distro_finders/distro_finder.py
@@ -1,0 +1,160 @@
+import logging
+import pathlib
+import shutil
+
+from colorama import Fore, Style
+
+from .. import utils
+from ..errors import InstallDestinationExistsError
+from ..parsers.distro_version import DistroVersion
+
+logger = logging.getLogger(__name__)
+
+
+class DistroFinder:
+    """A class used to find and install distros if required.
+
+    The class `DistroFinder` is used by hab in normal operation. Most of the the
+    other sub-classes like `DistroFinderZip` are used by the hab download system
+    to download and extract distro versions into the expected folder structure.
+
+    The aliases(programs) hab launches are normally not designed to load files
+    from inside of a .zip file so the contents of the distro need to be expanded
+    into a directory structure the alias can process.
+    """
+
+    hab_filename = ".hab.json"
+    """The file hab uses to define the distro relative to its root."""
+
+    def __init__(self, root, site=None):
+        self.site = site
+        self.root = utils.Platform.normalize_path(self.cast_path(root))
+        self.glob_str = f"*/{self.hab_filename}"
+
+    def __eq__(self, other):
+        if not hasattr(other, "root"):
+            return False
+        if not hasattr(other, "glob_str"):
+            return False
+        return self.root == other.root and self.glob_str == other.glob_str
+
+    def __str__(self):
+        return f"{self.root}"
+
+    def as_posix(self):
+        """Returns the root path as a posix style string."""
+        return self.root.as_posix()
+
+    def cast_path(self, path):
+        """Return path cast to the `pathlib.Path` like class preferred by this class."""
+        return pathlib.Path(path)
+
+    def clear_cache(self, persistent=False):
+        """Clear cached data in memory. If `persistent` is True then also remove
+        cache data from disk if it exists.
+        """
+        pass
+
+    def content(self, path):
+        """Returns the distro container for a given path as `pathlib.Path`.
+
+        The default implementation returns the directory containing the `hab_filename`
+        file but subclasses may return other objects like .zip files.
+
+        Args:
+            path (pathlib.Path): The path to the `hab_filename` file defining the distro.
+        """
+        return path.parent
+
+    def distro(self, forest, resolver, path):
+        """Returns an `DistroVersion` instance for the distro described py path.
+
+        Args:
+            forest: A dictionary of hab.parser objects used to initialize the return.
+            resolver (hab.Resolver): The Resolver used to initialize the return.
+            path (pathlib.Path): The path to the `hab_filename` file defining the
+                distro. This path is loaded into the returned instance.
+        """
+        distro = DistroVersion(forest, resolver, path, root_paths=set((self.root,)))
+        distro.finder = self
+        return distro
+
+    def distro_path_info(self):
+        """Generator yielding distro info for each distro found by this distro finder.
+
+        Note:
+            To use habcache features you must set the site property of this class
+            to the desired `hab.site.Site` class. If you don't then it will always
+            glob its results and cached will always be False.
+
+        Yields:
+            dirname: Each path passed by paths.
+            path: The path to a given resource for this dirname.
+            cached: If the path was stored in a .habcache file or required using glob.
+        """
+        # Handle if site has not been set, this does not use habcache.
+        if not self.site:
+            logger.debug("site not set, using direct glob.")
+            for path in utils.glob_path(self.root / self.glob_str):
+                yield self.root, self.cast_path(path), False
+
+        # Otherwise use the site cache to yield the results
+        cache = self.site.cache.distro_paths()
+        for dirname, path, cached in self.site.cache.iter_cache_paths(
+            "distro_paths", [self.root], cache, self.glob_str
+        ):
+            yield dirname, path, cached
+
+    def dump(self, verbosity=0, color=None, width=80):
+        """Return string representation of this object with various verbosity."""
+        if verbosity > 1:
+            if not color:
+                return f"{self.root} [{type(self).__name__}]"
+            return f"{self.root} {Fore.CYAN}[{type(self).__name__}]{Style.RESET_ALL}"
+        return str(self)
+
+    def install(self, path, dest):
+        """Install the distro into dest.
+
+        Args:
+            path (pathlib.Path): The path to the `hab_filename` file defining the
+                distro. This path is used to find the `content` of the distro.
+            dest (pathlib.Path or str): The directory to install the distro into.
+                The contents of the distro are installed into this directory.
+                All intermediate directories needed to contain dest will be created.
+        """
+        path = self.content(path)
+        if dest.exists():
+            raise InstallDestinationExistsError(dest)
+        logger.debug(f"Installing to {dest} from source {path}")
+        shutil.copytree(path, dest)
+
+    def installed(self, path):
+        """Returns if the hab_filename exists inside the root location"""
+        return (path / self.hab_filename).exists()
+
+    def load_path(self, path):
+        """Returns a raw dictionary use to create a `DistroVersion` or None.
+
+        The return is passed to `DistroVersion.load` as the data argument. This
+        allows the `DistroFinder` class to bypass the normal json loading method
+        for distros.
+
+        This is called by `distro` and used by sub-classes to more efficiently
+        load the distro dictionary when possible. The default class returns `None`.
+
+        Args:
+            path (pathlib.Path): The path to the `hab_filename` file defining the
+                distro used to define the returned data.
+        """
+        # By default return None to use the `DistroVersion._load` method.
+        return None
+
+    @property
+    def site(self):
+        """A `hab.site.Site` instance used to enable habcache."""
+        return self._site
+
+    @site.setter
+    def site(self, site):
+        self._site = site

--- a/hab/distro_finders/s3_zip.py
+++ b/hab/distro_finders/s3_zip.py
@@ -1,0 +1,92 @@
+import logging
+import sys
+from hashlib import sha256
+
+from cloudpathlib import S3Client
+from requests_aws4auth import AWS4Auth
+
+from .. import utils
+from .cloud_zip import DistroFinderCloudZip
+
+logger = logging.getLogger(__name__)
+
+if sys.version_info.minor <= 7:
+    import warnings
+
+    warnings.warn(
+        "Boto3 no longer supports python 3.7. You should use a newer python "
+        "version for hab install support.",
+        DeprecationWarning,
+    )
+
+
+class DistroFinderS3Zip(DistroFinderCloudZip):
+    """Works with zipped distros stored remotely in Amazon S3 buckets.
+
+    Working with zipped distros extracting the `hab_filename` information from
+    inside the .zip file. This is useful when you have direct access to the .zip
+    file.
+
+    For `path`, this class uses a .zip `member path`. A member path is the absolute
+    path to the .zip joined with the member path of files contained inside the .zip
+    file. So if the archive file path is `c:/temp/dist_a_v0.1.zip` and the member is
+    `hab_filename`, then the member_path would be `c:/temp/dist_a_v0.1.zip/.hab.json`.
+
+    Note:
+        This class should only be used to install distros in the hab download system.
+
+    This expects one file to exist with a specific naming convention:
+        - `{distro}_v{version}.zip` contains the entire contents of the distro.
+          This should also contain the top level file `hab_filename`. When the distro
+          is installed and using hab normally this file will be used. The `hab_filename`
+          file's contents are extracted from the zip file and used to initialize the
+          `DistroVersion` returned by `self.distro` without being written to disk.
+    """
+
+    def __init__(self, root, site=None, safe=False, client=None, **client_kwargs):
+        self.client_kwargs = client_kwargs
+        super().__init__(root, site=site, safe=safe, client=client)
+
+    @property
+    def client(self):
+        try:
+            return self._client
+        except AttributeError:
+            kwargs = self.client_kwargs
+            if self.site:
+                kwargs["local_cache_dir"] = self.site.downloads["cache_root"]
+            else:
+                kwargs["local_cache_dir"] = utils.Platform.default_download_cache()
+            self._client = S3Client(**kwargs)
+        return self._client
+
+    @client.setter
+    def client(self, client):
+        self._client = client
+
+    def credentials(self):
+        """Returns the credentials needed for requests to connect to aws s3 bucket.
+
+        Generates these credentials using the client object.
+        """
+
+        try:
+            return self._credentials
+        except AttributeError:
+            pass
+        # The `x-amz-content-sha256` header is required for all AWS Signature
+        # Version 4 requests. It provides a hash of the request payload. If
+        # there is no payload, you must provide the hash of an empty string.
+        headers = {"x-amz-content-sha256": sha256(b"").hexdigest()}
+
+        location = self.client.client.get_bucket_location(Bucket=self.root.bucket)[
+            "LocationConstraint"
+        ]
+        auth = AWS4Auth(
+            refreshable_credentials=self.client.sess.get_credentials(),
+            region=location,
+            service="s3",
+        )
+
+        self._credentials = (auth, headers)
+        return self._credentials

--- a/hab/distro_finders/zip_sidecar.py
+++ b/hab/distro_finders/zip_sidecar.py
@@ -1,0 +1,154 @@
+import logging
+import re
+import zipfile
+
+from packaging.version import VERSION_PATTERN
+
+from .. import utils
+from ..errors import InstallDestinationExistsError
+from ..parsers.lazy_distro_version import LazyDistroVersion
+from .distro_finder import DistroFinder
+
+logger = logging.getLogger(__name__)
+
+
+class DistroFinderZipSidecar(DistroFinder):
+    """Working with zipped distros that have a sidecar `dist_name_v0.0.0.hab.json`
+    file. This is useful when it can't extract the `hab_filename` from the .zip file.
+
+    Note:
+        This class should only be used to install distros in the hab download system.
+
+    This expects two files to exist with a specific naming convention:
+        - `{distro}_v{version}.zip` contains the entire contents of the distro.
+          This should also contain the top level file `hab_filename`. When the distro
+          is installed and using hab normally this file will be used.
+        - `{distro}_v{version}.hab.json` is a copy of the .hab.json file contained
+          in the .zip file. This file is used to initialize the `DistroVersion`
+          returned by `self.distro` and mainly used to resolve dependent distros
+          efficiently when running hab download. It is not used outside of this class.
+    """
+
+    version_regex = re.compile(
+        rf"(?P<name>[^\\/]+)_v{VERSION_PATTERN}", flags=re.VERBOSE | re.IGNORECASE
+    )
+    """Regex used to parse the distro name and version from a file path. This looks
+    for a string matching {distro}_v{version}.
+    """
+
+    def __init__(self, root, site=None):
+        super().__init__(root, site)
+        self.glob_str = "*.hab.json"
+
+    def archive(self, zip_path, partial=True):
+        """Returns a `zipfile.Zipfile` like instance for zip_path.
+
+        Args:
+            zip_path (os.PathLike): The path to the zip file to open.
+            partial (bool, optional): If True then you only need access to a small
+                part of the archive. This is used by sub-classes to optimize access
+                to remote zip archives. If True then `HabRemoteZip` will be used
+                to only download specific files from the remote archive without
+                caching them to disk. If False then remote archives will be fully
+                downloaded to disk(using caching) before returning the open archive.
+        """
+        return zipfile.ZipFile(zip_path)
+
+    def content(self, path):
+        """Returns the distro container for a given path as `pathlib.Path`.
+
+        For this class it returns the path to the sidecar .zip file. This .zip
+        file contains the contents of the distro.
+
+        Args:
+            path (pathlib.Path): The path to the `hab_filename` file defining the distro.
+        """
+        # This simply replaces `hab_filename` with `.zip`.
+        return path.with_suffix("").with_suffix(".zip")
+
+    def content_member(self, path):
+        """Splits a member path into content and member.
+
+        Args:
+            path (os.PathLike): The member path to split.
+
+        Returns:
+            content(os.PathLike): Path to the .zip file.
+            member (str): This class always returns `hab_filename`.
+        """
+        content = self.content(path)
+        return content, self.hab_filename
+
+    def distro(self, forest, resolver, path):
+        """Returns an `DistroVersion` instance for the distro described py path.
+
+        Args:
+            forest: A dictionary of hab.parser objects used to initialize the return.
+            resolver (hab.Resolver): The Resolver used to initialize the return.
+            path (pathlib.Path): The path to the `hab_filename` file defining the
+                distro. This path is loaded into the returned instance.
+        """
+        distro = LazyDistroVersion(forest, resolver, root_paths=set((self.root,)))
+        distro.finder = self
+        distro.name, distro.version = self.version_for_path(path)
+        distro.distro_name = distro.name
+        distro.load(path)
+        return distro
+
+    def install(self, path, dest, replace=False):
+        """Install the distro into dest.
+
+        Args:
+            path (os.PathLike): The path to the `hab_filename` file defining the
+                distro. This path is used to find the `content` of the distro.
+            dest (pathlib.Path): The directory to install the distro into.
+                The contents of the distro are installed into this directory.
+                All intermediate directories needed to contain dest will be created.
+            replace (bool, optional): If the distro already exists, remove and
+                re-copy it. Otherwise raises an Exception.
+        """
+        path, member = self.content_member(path)
+        if (dest / member).exists():
+            if not replace:
+                raise InstallDestinationExistsError(dest)
+
+        logger.debug(f"Extracting to {dest} from zip {path}")
+        with self.archive(path, partial=False) as archive:
+            members = archive.namelist()
+            total = len(members)
+            for i, member in enumerate(members):
+                logger.debug(f"Extracting file({i}/{total}): {member}")
+                archive.extract(member, dest)
+            return True
+
+    def load_path(self, path):
+        """Returns a raw dictionary use to create a `DistroVersion` with version set.
+
+        The return is passed to `DistroVersion.load` as the data argument. This
+        allows the `DistroFinder` class to bypass the normal json loading method
+        for distros.
+
+        Returns the contents of the sidecar `{distro}_v{version}.hab.json` file.
+        The version property will always be set in the return. If not defined
+        in the file's contents, its set to the return of `version_for_path`.
+
+        Args:
+            path (pathlib.Path): The path to the `hab_filename` file defining the
+                distro used to define the returned data.
+        """
+        logger.debug(f'Loading "{path}"')
+        data = utils.load_json_file(path)
+        # Pull the version from the sidecar filename if its not explicitly set
+        if "version" not in data:
+            _, data["version"] = self.version_for_path(path)
+        return data
+
+    def version_for_path(self, path):
+        """Returns the distro name and version for the given path as a string.
+
+        Args:
+            path (pathlib.Path): The path to the `*.hab.json` file defining the
+                distro. Uses the `version_regex` to parse the version release.
+        """
+        result = self.version_regex.search(str(path))
+        return result.group("name"), result.group("release")

--- a/hab/errors.py
+++ b/hab/errors.py
@@ -1,3 +1,6 @@
+import errno
+
+
 class HabError(Exception):
     """Base class for all hab errors."""
 
@@ -70,6 +73,13 @@ class InvalidVersionError(LookupError):
         if self.error:
             ret = f"[{type(self.error).__name__}] {self.error}\n{ret}"
         return ret
+
+
+class InstallDestinationExistsError(HabError, FileExistsError):
+    """Raised if attempting to install to a directory that already exists."""
+
+    def __init__(self, filename, message="The destination already exists"):
+        super().__init__(errno.EEXIST, message, filename)
 
 
 class ReservedVariableNameError(HabError):

--- a/hab/launcher.py
+++ b/hab/launcher.py
@@ -3,13 +3,6 @@ import sys
 
 from . import utils
 
-try:
-    CREATE_NO_WINDOW = subprocess.CREATE_NO_WINDOW
-except AttributeError:
-    # This constant comes from the WindowsAPI, but is not
-    # defined in subprocess until python 3.7
-    CREATE_NO_WINDOW = 0x08000000
-
 
 class Launcher(subprocess.Popen):
     """Runs cmd using subprocess.Popen enabling stdout/err/in redirection.
@@ -42,6 +35,6 @@ class Launcher(subprocess.Popen):
 
             # If this is a pythonw process, because there is no current window
             # for stdout, any subprocesses will try to create a new window
-            kwargs.setdefault("creationflags", CREATE_NO_WINDOW)
+            kwargs.setdefault("creationflags", subprocess.CREATE_NO_WINDOW)
 
         super().__init__(args, **kwargs)

--- a/hab/merge_dict.py
+++ b/hab/merge_dict.py
@@ -53,18 +53,23 @@ class MergeDict(object):
         """Apply string formatting rules to the given value if applicable.
 
         If value is a list, this method is recursively called on the contents
-        and a new list is returned. If a bool or dict are passed, they are
-        returned without modification. Otherwise its assume to be a string and
-        str.format is called passing `self.format_kwargs`.
+        and a new list is returned. It is similarly called on the values of dict's.
+        If a bool or int are passed, they are returned without modification.
+        Otherwise its assume to be a string and str.format is called passing
+        `self.format_kwargs`.
 
         If `self.site` is set and platform is passed, site.platform_path_map is called
         on the text output to convert it to the desired platform.
         """
+        if value is None:
+            return value
         if isinstance(value, list):
             # Format the individual items if a list of args is used.
             # return [v.format(**self.format_kwargs) for v in value]
             return [self.default_format(v) for v in value]
-        if isinstance(value, (bool, dict, int)):
+        if isinstance(value, dict):
+            return {k: self.formatter(v, platform=platform) for k, v in value.items()}
+        if isinstance(value, (bool, int)):
             return value
         ret = value.format(**self.format_kwargs)
 

--- a/hab/parsers/distro_version.py
+++ b/hab/parsers/distro_version.py
@@ -16,6 +16,7 @@ class DistroVersion(HabBase):
 
     def __init__(self, *args, **kwargs):
         self._alias_mods = NotSet
+        self._finder = None
         super().__init__(*args, **kwargs)
 
     def _cache(self):
@@ -96,6 +97,15 @@ class DistroVersion(HabBase):
         """
         return self._alias_mods
 
+    @hab_property(verbosity=3)
+    def finder(self):
+        """The DistroFinder instance used to create this instance."""
+        return self._finder
+
+    @finder.setter
+    def finder(self, value):
+        self._finder = value
+
     def _load(self, filename, cached=True):
         """Sets self.filename and parses the json file returning the data."""
         ret = super()._load(filename, cached=cached)
@@ -108,9 +118,10 @@ class DistroVersion(HabBase):
             ret["version"] = str(self.version)
         return ret
 
-    def load(self, filename):
+    def load(self, filename, data=None):
         # Fill in the DistroVersion specific settings before calling super
-        data = self._load(filename)
+        if data is None:
+            data = self._load(filename)
 
         # The name should be the version == specifier.
         self.distro_name = data.get("name")

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -473,7 +473,9 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
             self._filename = Path(os.devnull)
             self._dirname = Path(os.devnull)
         else:
-            self._filename = Path(filename)
+            if isinstance(filename, str):
+                filename = Path(filename)
+            self._filename = filename
             self._dirname = self._filename.parent
 
     def format_environment_value(self, value, ext=None, platform=None):
@@ -594,12 +596,16 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
         """Load this objects configuration from the given json filename.
 
         Args:
-            filename (str): The json file to load the config from.
+            filename: The file to load the config from. If this is a string it is
+                cast to a `pathlib.Path` object, otherwise it is expected to be
+                a `pathlib.Path` like object.
             data (dict, optional): If provided this dict is used instead of parsing
                 the json file. In this case filename is ignored.
         """
         if data is None:
             data = self._load(filename)
+        else:
+            self.filename = filename
 
         # Check for NotSet so sub-classes can set values before calling super
         if self.name is NotSet:

--- a/hab/parsers/lazy_distro_version.py
+++ b/hab/parsers/lazy_distro_version.py
@@ -1,0 +1,127 @@
+import logging
+import shutil
+from pathlib import Path
+
+from .. import NotSet
+from ..errors import InstallDestinationExistsError
+from .distro_version import DistroVersion
+
+logger = logging.getLogger(__name__)
+
+
+class DistroPath:
+    __slots__ = ("distro", "hab_filename", "root", "site")
+
+    def __init__(self, distro, root, relative=NotSet, site=None):
+        self.distro = distro
+        self.site = site
+        if isinstance(root, str):
+            root = Path(root)
+
+        if relative is NotSet:
+            if site and "relative_path" in site.downloads:
+                relative = site.downloads["relative_path"]
+            else:
+                relative = "{distro_name}/{version}"
+
+        if relative:
+            root = root / relative.format(
+                name=self.distro.name,
+                distro_name=self.distro.distro_name,
+                version=self.distro.version,
+            )
+
+        self.hab_filename = root / ".hab.json"
+        self.root = root
+
+
+class LazyDistroVersion(DistroVersion):
+    """A DistroVersion class that loads data on first access.
+
+    This class will raise a ValueError if filename is passed. This class expects
+    that after initializing you set the properties `name`, `version`, `finder`,
+    and `distro_name` After that you should call `load(filename)`.
+
+    TODO: Add overrides to each getter/setter on this class like we have done to
+    the distros property.
+    """
+
+    def __init__(self, *args, **kwargs):
+        if len(args) > 2 or "filename" in kwargs:
+            raise ValueError("Passing filename to this class is not supported.")
+
+        self._loaded = False
+        self._loaded_data = NotSet
+        super().__init__(*args, **kwargs)
+
+    @DistroVersion.distros.getter
+    def distros(self):
+        """A list of all of the requested distros to resolve."""
+        self._ensure_loaded()
+        return super().distros
+
+    def install(self, dest, replace=False, relative=NotSet):
+        """Install the distro into dest.
+
+        Installs the distro into `dest / relative` creating any intermediate
+        directories needed. In most cases you would pass one of your site's
+        `distro_paths` to `dist` and the default relative value creates the
+        recommended distro/version/contents folder structure that ensures that
+        each distro version doesn't conflict with any others.
+
+        Args:
+            dest (pathlib.Path or str): The base directory to install this distro
+                into. This is joined with `relative` to create the full path.
+            replace (bool, optional): If dest already contains this distro, this
+                will remove the existing install then re-install the distro.
+            relative (str, optional): Additional path items joined to dest after
+                being formatted. The kwargs "name", "distro_name" and "version"
+                are passed to the `str.format` called on this variable.
+
+        Raises:
+            hab.errors.InstallDestinationExistsError: If the requested dest already
+                contains this distro this error is raised and it is not installed.
+                Unless `replace` is set to True.
+        """
+        if not isinstance(dest, DistroPath):
+            dest = DistroPath(self, dest, relative=relative, site=self.resolver.site)
+
+        installed = self.installed(dest, relative=relative)
+        if installed:
+            if not replace:
+                raise InstallDestinationExistsError(dest.root)
+            # Replace requested, remove the existing files before continuing.
+            logger.info(f"Removing existing distro install: {dest.root}")
+            shutil.rmtree(dest.root)
+
+        self.finder.install(self.filename, dest.root)
+        # The resolver cache is now out of date, force it to refresh on next access.
+        self.resolver.clear_caches()
+
+    def installed(self, dest, relative=NotSet):
+        if not isinstance(dest, DistroPath):
+            dest = DistroPath(self, dest, relative=relative, site=self.resolver.site)
+        return dest.hab_filename.exists()
+
+    def _ensure_loaded(self):
+        """Ensures the data is loaded.
+
+        On first call this method actually processes the loading of data for
+        this DistroVersion. Any additional calls are ignored.
+        """
+        if self._loaded:
+            return
+
+        self._loaded = True
+        data = self.finder.load_path(self.filename)
+        return super().load(self.filename, data=data)
+
+    def load(self, filename, data=NotSet):
+        # The name should be the version == specifier.
+        self.name = f"{self.distro_name}=={self.version}"
+
+        self.filename = filename
+        self._loaded_data = data
+        self._loaded = False
+        self.context = [self.distro_name]
+        return data

--- a/hab/resolver.py
+++ b/hab/resolver.py
@@ -149,6 +149,7 @@ class Resolver(object):
 
     @config_paths.setter
     def config_paths(self, paths):
+        """Path's used to populate `configs`."""
         # Convert string paths into a list
         if isinstance(paths, str):
             paths = utils.Platform.expand_paths(paths)
@@ -374,6 +375,9 @@ class Resolver(object):
             MaxRedirectError: Redirect limit reached, unable to resolve the requested
                 requirements.
         """
+
+        if isinstance(requirements, list):
+            requirements = Solver.simplify_requirements(requirements)
 
         solver = Solver(
             requirements, self, forced=self.forced_requirements, omittable=omittable

--- a/hab/user_prefs.py
+++ b/hab/user_prefs.py
@@ -131,16 +131,10 @@ class UserPrefs(dict):
 
     @classmethod
     def _fromisoformat(cls, value):
-        """Calls `datetime.fromisoforamt` if possible otherwise replicates
-        its basic requirements (for python 3.6 support).
-        """
+        """Calls `datetime.fromisoformat` unless a datetime is passed."""
         if isinstance(value, datetime.datetime):
             return value
-        try:
-            return datetime.datetime.fromisoformat(value)
-        except AttributeError:
-            iso_format = r"%Y-%m-%dT%H:%M:%S.%f"
-            return datetime.datetime.strptime(value, iso_format)
+        return datetime.datetime.fromisoformat(value)
 
     def uri_check(self):
         """Returns the uri saved in preferences. It will only do that if enabled

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -109,7 +109,7 @@ def decode_freeze(txt):
     return json.loads(data)
 
 
-def dump_object(obj, label="", width=80, flat_list=False, color=False):
+def dump_object(obj, label="", width=80, flat_list=False, color=False, verbosity=0):
     """Recursively convert python objects into a human readable table string.
 
     Args:
@@ -128,6 +128,7 @@ def dump_object(obj, label="", width=80, flat_list=False, color=False):
             item to be broken into multiple lines.
         color (bool, optional): Use ANSI escape character sequences to colorize
             the output of the text.
+        verbosity (int, optional): More information is shown with higher values.
     """
     pad = " " * len(label)
     if label:
@@ -140,7 +141,10 @@ def dump_object(obj, label="", width=80, flat_list=False, color=False):
     if isinstance(obj, (list, KeysView)):
         rows = []
         obj = [
-            dump_object(o, width=width, flat_list=flat_list, color=color) for o in obj
+            dump_object(
+                o, width=width, flat_list=flat_list, color=color, verbosity=verbosity
+            )
+            for o in obj
         ]
         if flat_list:
             # combine as many list items as possible onto each line
@@ -178,12 +182,16 @@ def dump_object(obj, label="", width=80, flat_list=False, color=False):
                     width=width,
                     flat_list=flat_list,
                     color=color,
+                    verbosity=verbosity,
                 )
             )
             lbl = pad
         return "\n".join(rows)
     elif isinstance(obj, PurePath):
         return f"{label}{obj}"
+    elif hasattr(obj, "dump"):
+        # If the class implements a dump method, return its result
+        return obj.dump(verbosity=verbosity, color=color, width=width)
     elif hasattr(obj, "name"):
         # Likely HabBase objects
         return f"{label}{obj.name}"

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -13,7 +13,7 @@ from collections import UserDict
 from collections.abc import KeysView
 from contextlib import contextmanager
 from datetime import date, datetime
-from pathlib import Path, PurePath
+from pathlib import Path, PurePath, PureWindowsPath
 
 import colorama
 
@@ -27,6 +27,20 @@ except ImportError:
 
     class _JsonException(BaseException):
         """Placeholder exception when pyjson5 is not used. Should never be raised"""
+
+
+# cloudpathlib is an optional library, if installed then this will enable
+# `dump_object` to print its full path instead of just the filename.
+try:
+    from cloudpathlib import CloudPath as _CloudPath
+except ImportError:
+
+    class _CloudPath:
+        """Placeholder class because `cloudpathlib` is not importable.
+        Used for isinstance checking.
+        """
+
+        pass
 
 
 colorama.init()
@@ -187,7 +201,7 @@ def dump_object(obj, label="", width=80, flat_list=False, color=False, verbosity
             )
             lbl = pad
         return "\n".join(rows)
-    elif isinstance(obj, PurePath):
+    elif isinstance(obj, (PurePath, _CloudPath)):
         return f"{label}{obj}"
     elif hasattr(obj, "dump"):
         # If the class implements a dump method, return its result
@@ -302,6 +316,39 @@ class HabJsonEncoder(_json.JSONEncoder):
         return _json.JSONEncoder.default(self, obj)
 
 
+def _load_json(source, load_funct, *args, **kwargs):
+    """Work function that parses json and ensures any errors report the source.
+
+    Args:
+        source (os.PathLike or str): The source of the json data. This is reported
+            in any raised exceptions.
+        load_funct (callable): A function called to parse the json data. Normally
+            this is `json.load` or `json.loads`.
+        *args: Arguments passed to `load_funct`.
+        *kwargs: Keyword arguments passed to `load_funct`.
+
+    Raises:
+        FileNotFoundError: If filename is not pointing to a file that actually exists.
+        pyjson5.Json5Exception: If using pyjson5, the error raised due to invalid json.
+        ValueError: If not using pyjson5, the error raised due to invalid json.
+    """
+    try:
+        return load_funct(*args, **kwargs)
+    # Include the filename in the traceback to make debugging easier
+    except _JsonException as e:
+        # pyjson5 is installed add filename to the traceback
+        if e.result is None:
+            # Depending on the exception result may be None, convert it
+            # into a empty dict so we can add the filename
+            e.args = e.args[:1] + ({},) + e.args[2:]
+        e.result["source"] = str(source)
+        raise e.with_traceback(sys.exc_info()[2]) from None
+    except ValueError as e:
+        # Using python's native json parser
+        msg = f'{e} Source("{source}")'
+        raise type(e)(msg, e.doc, e.pos).with_traceback(sys.exc_info()[2]) from None
+
+
 def load_json_file(filename):
     """Open and parse a json file. If a parsing error happens the file path is
     added to the exception to allow for easier debugging.
@@ -321,22 +368,28 @@ def load_json_file(filename):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), str(filename))
 
     with filename.open() as fle:
-        try:
-            data = json.load(fle)
-        # Include the filename in the traceback to make debugging easier
-        except _JsonException as e:
-            # pyjson5 is installed add filename to the traceback
-            if e.result is None:
-                # Depending on the exception result may be None, convert it
-                # into a empty dict so we can add the filename
-                e.args = e.args[:1] + ({},) + e.args[2:]
-            e.result["filename"] = str(filename)
-            raise e.with_traceback(sys.exc_info()[2]) from None
-        except ValueError as e:
-            # Using python's native json parser
-            msg = f'{e} Filename("{filename}")'
-            raise type(e)(msg, e.doc, e.pos).with_traceback(sys.exc_info()[2]) from None
+        data = _load_json(filename, json.load, fle)
     return data
+
+
+def loads_json(json_string, source):
+    """Open and parse a json string. If a parsing error happens the source file
+    path is added to the exception to allow for easier debugging.
+
+    Args:
+        json_string (str): The json data to parse.
+        source (pathlib.Path): The location json_string was pulled from. This is
+            reported if any parsing errors happen.
+
+    Returns:
+        The data stored in the json file.
+
+    Raises:
+        FileNotFoundError: If filename is not pointing to a file that actually exists.
+        pyjson5.Json5Exception: If using pyjson5, the error raised due to invalid json.
+        ValueError: If not using pyjson5, the error raised due to invalid json.
+    """
+    return _load_json(source, json.loads, json_string)
 
 
 def natural_sort(ls, key=None):
@@ -607,12 +660,20 @@ class WinPlatform(BasePlatform):
 
         This ensures that the drive letter is resolved consistently to uppercase.
         """
-        # Don't change the case of relative or UNC paths
-        if not path.is_absolute() or ":" not in path.drive:
+        if (
+            # Don't change the case of relative or UNC paths
+            not path.is_absolute()
+            or ":" not in path.drive
+            # We only need to modify absolute WindowsPaths here, `CloudPath.is_absolute`
+            # always returns True, but does not inherit from PureWindowsPath.
+            # This prevents `CloudPath.client` from getting lost by the recast below.
+            or not isinstance(path, PureWindowsPath)
+        ):
             return path
+
         parts = path.parts
-        cls = type(path)
-        return cls(parts[0].upper()).joinpath(*parts[1:])
+        path_cls = type(path)
+        return path_cls(parts[0].upper()).joinpath(*parts[1:])
 
     @classmethod
     def pathsep(cls, ext=None, key=None):

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -6,6 +6,7 @@ import ntpath
 import os
 import re
 import sys
+import tempfile
 import textwrap
 import zlib
 from abc import ABC, abstractmethod
@@ -541,6 +542,14 @@ class BasePlatform(ABC):
     def default_ext(cls):
         """Returns the default file extension used on this platform."""
         return cls._default_ext
+
+    @classmethod
+    def default_download_cache(cls):
+        """Path where download files are cached.
+
+        This is used as the default location for `Site.downloads["cache_root"]`.
+        """
+        return Path(tempfile.gettempdir()) / "hab_downloads"
 
     @classmethod
     def expand_paths(cls, paths):

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -269,6 +269,24 @@ def encode_freeze(data, version=None, site=None):
     return f'v{version}:{data.decode("utf-8")}'
 
 
+def glob_path(path):
+    """Process any wildcards in the provided `pathlib.Path` like instance.
+
+    While a `pathlib.Path` can be created with a glob string you won't be able to
+    resolve the glob into files. This function breaks the path down to its top level
+    item and calls `Path.glob` on the remaining path. So `Path("/mnt/*/.hab.json")`
+    gets converted into `Path("/mnt").glob("*/.hab.json")`.
+
+    The input path will be converted to a `pathlib.Path` object for this operation.
+
+    Based on https://stackoverflow.com/a/51108375
+    """
+    # Strip the path into its parts removing the root of absolute paths.
+    parts = path.parts[1:]
+    # From the root run a glob search on all parts of the glob string
+    return Path(path.parts[0]).glob(str(Path(*parts)))
+
+
 class HabJsonEncoder(_json.JSONEncoder):
     """JsonEncoder class that handles non-supported objects like hab.NotSet."""
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     importlib-metadata
     packaging>=20.0
     setuptools-scm[toml]>=4
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 scripts =
     bin/.hab-complete.bash

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,9 @@ scripts =
 exclude = tests
 
 [options.extras_require]
+cloud =
+    cloudpathlib
+    remotezip
 dev =
     black==22.12.0
     covdefaults
@@ -62,6 +65,10 @@ dev =
     tox
 json5 =
     pyjson5
+s3 =
+    cloudpathlib[s3]
+    remotezip
+    requests-aws4auth
 
 [flake8]
 select = B, C, E, F, N, W, B9

--- a/tests/site/site_distro_finder.json
+++ b/tests/site/site_distro_finder.json
@@ -1,0 +1,32 @@
+{
+    "set":
+    {
+        "distro_paths":
+        [
+            [
+                "hab.distro_finders.distro_finder:DistroFinder",
+                "hab testable/download/path"
+            ],
+            [
+                "hab.distro_finders.distro_finder:DistroFinder",
+                "hab testing/downloads",
+                {
+                    "site": "for testing only, do not specify site"
+                }
+            ]
+        ],
+        "downloads":
+        {
+            "cache_root": "hab testable/download/path",
+            "distros":
+            [
+                [
+                    "hab.distro_finders.df_zip:DistroFinderZip",
+                    "network_server/distro/source"
+                ]
+            ],
+            "install_root": "{relative_root}/distros",
+            "relative_path": "{{distro_name}}_v{{version}}"
+        }
+    }
+}

--- a/tests/site/site_distro_finder_empty.json
+++ b/tests/site/site_distro_finder_empty.json
@@ -1,0 +1,7 @@
+{
+    "set": {
+        "downloads": {
+            "cache_root": ""
+        }
+    }
+}

--- a/tests/templates/site_distro_finder.json
+++ b/tests/templates/site_distro_finder.json
@@ -1,0 +1,20 @@
+{
+    "set": {
+        "config_paths": [
+            "{relative_root}/configs"
+        ],
+        "distro_paths": [
+            "{relative_root}/distros/*"
+        ],
+        "downloads": {
+            "cache_root": "{relative_root}/downloads",
+            "distros": [
+                [
+                    "hab.distro_finders.distro_finder:DistroFinder",
+                    "{{ zip_root }}/*"
+                ]
+            ],
+            "install_root": "{relative_root}/distros"
+        }
+    }
+}

--- a/tests/templates/site_distro_s3.json
+++ b/tests/templates/site_distro_s3.json
@@ -1,0 +1,24 @@
+{
+    "set": {
+        "config_paths": [
+            "{relative_root}/configs"
+        ],
+        "distro_paths": [
+            "{relative_root}/distros/*"
+        ],
+        "downloads": {
+            "cache_root": "{relative_root}/downloads",
+            "distros": [
+                [
+                    "hab.distro_finders.s3_zip:DistroFinderS3Zip",
+                    "s3://hab-test-bucket",
+                    {
+                        "no_sign_request": true,
+                        "local_storage_dir": "{{ zip_root }}"
+                    }
+                ]
+            ],
+            "install_root": "{relative_root}/distros"
+        }
+    }
+}

--- a/tests/templates/site_distro_zip.json
+++ b/tests/templates/site_distro_zip.json
@@ -1,0 +1,20 @@
+{
+    "set": {
+        "config_paths": [
+            "{relative_root}/configs"
+        ],
+        "distro_paths": [
+            "{relative_root}/distros/*"
+        ],
+        "downloads": {
+            "cache_root": "{relative_root}/downloads",
+            "distros": [
+                [
+                    "hab.distro_finders.df_zip:DistroFinderZip",
+                    "{{ zip_root }}"
+                ]
+            ],
+            "install_root": "{relative_root}/distros"
+        }
+    }
+}

--- a/tests/templates/site_distro_zip_sidecar.json
+++ b/tests/templates/site_distro_zip_sidecar.json
@@ -1,0 +1,20 @@
+{
+    "set": {
+        "config_paths": [
+            "{relative_root}/configs"
+        ],
+        "distro_paths": [
+            "{relative_root}/distros/*"
+        ],
+        "downloads": {
+            "cache_root": "{relative_root}/downloads",
+            "distros": [
+                [
+                    "hab.distro_finders.zip_sidecar:DistroFinderZipSidecar",
+                    "{{ zip_root }}"
+                ]
+            ],
+            "install_root": "{relative_root}/distros"
+        }
+    }
+}

--- a/tests/templates/site_download.json
+++ b/tests/templates/site_download.json
@@ -1,0 +1,20 @@
+{
+    "set": {
+        "config_paths": [
+            "{relative_root}/configs"
+        ],
+        "distro_paths": [
+            "{relative_root}/distros/*"
+        ],
+        "downloads": {
+            "cache_root": "{relative_root}/downloads",
+            "distros": [
+                [
+                    "hab.distro_finders.df_zip:DistroFinderZip",
+                    "{{ zip_root }}"
+                ]
+            ],
+            "install_root": "{relative_root}/distros"
+        }
+    }
+}

--- a/tests/test_distro_finder.py
+++ b/tests/test_distro_finder.py
@@ -1,0 +1,830 @@
+import glob
+import json
+import logging
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from hab import DistroMode, Resolver, Site, utils
+from hab.distro_finders import df_zip, distro_finder, zip_sidecar
+from hab.errors import HabError, InstallDestinationExistsError, InvalidRequirementError
+from hab.parsers import DistroVersion
+from hab.parsers.lazy_distro_version import LazyDistroVersion
+
+
+def test_distro_finder_entry_point(config_root):
+    """Test edge cases for DistroFinder entry_point processing."""
+    paths = [config_root / "site" / "site_distro_finder.json"]
+    site = Site(paths)
+    distro_paths = site["distro_paths"]
+    # Ensure the DistroFinder paths are set correctly when set as EntryPoint
+    assert distro_paths[0].root == Path("hab testable") / "download" / "path"
+    assert distro_paths[1].root == Path("hab testing") / "downloads"
+    # The second path passes the kwargs dict with `site`. This triggers testing
+    # when a dict is passed to the entry_point. However site is always set to
+    # the current site after a DistroFinder is initialized.
+    assert distro_paths[1].site == site
+
+
+def test_eq():
+    a = distro_finder.DistroFinder("path/a")
+
+    assert a == distro_finder.DistroFinder("path/a")
+    assert a != distro_finder.DistroFinder("path/b")
+
+    # Test that if the glob_str is different it will not compare equal
+    b = distro_finder.DistroFinder("path/a")
+    b.glob_str = "*/test.json"
+    assert a != b
+    # Test that if glob_str attr is missing it will not compare equal
+    del b.glob_str
+    assert a != b
+    # Restore glob_str and the objects will compare equal again
+    b.glob_str = "*/.hab.json"
+    assert a == b
+
+    # Test that if the root is different it will not compare equal
+    b.root = Path(".")
+    assert a != b
+    # Test that if root attr is missing it will not compare equal
+    del b.root
+    assert a != b
+    # Restore root and the objects will compare equal again
+    b.root = Path("path/a")
+    assert a == b
+
+
+@pytest.mark.parametrize(
+    "glob_str,count",
+    (
+        ("{root}/reference*/sh_*", 12),
+        ("{root}/reference/*", 0),
+        ("{root}/reference_scripts/*/*.sh", 20),
+    ),
+)
+def test_glob_path(config_root, glob_str, count):
+    """Ensure `hab.utils.glob_path` returns the expected results."""
+    glob_str = glob_str.format(root=config_root)
+    # Check against the `glob.glob` result.
+    check = sorted([Path(p) for p in glob.glob(glob_str)])
+
+    path_with_glob = Path(glob_str)
+    result = sorted(utils.glob_path(path_with_glob))
+
+    assert result == check
+    # Sanity check to ensure that the expected results were found by `glob.glob`
+    assert len(result) == count
+
+
+class CheckDistroFinder:
+    distro_finder_cls = distro_finder.DistroFinder
+    site_template = "site_distro_finder.json"
+
+    def create_resolver(self, zip_root, helpers, tmp_path):
+        """Create a hab site for the test."""
+        return helpers.render_resolver(
+            self.site_template, tmp_path, zip_root=zip_root.as_posix()
+        )
+
+    def check_installed(self, a_distro_finder, helpers, tmp_path):
+        resolver = self.create_resolver(a_distro_finder.root, helpers, tmp_path)
+        finder = resolver.distro_paths[0]
+        distro_folder = resolver.site.downloads["install_root"] / "dist_a" / "0.1"
+
+        # The distro is not installed yet
+        assert not distro_folder.exists()
+        assert not finder.installed(distro_folder)
+
+        # Simulate installing by creating the .hab.json file(contents doesn't matter)
+        distro_folder.mkdir(parents=True)
+        with (distro_folder / ".hab.json").open("w"):
+            pass
+        assert finder.installed(distro_folder)
+
+    def check_install(self, a_distro_finder, helpers, tmp_path):
+        resolver = self.create_resolver(a_distro_finder.zip_root, helpers, tmp_path)
+        dl_finder = resolver.site.downloads["distros"][0]
+        assert isinstance(dl_finder, self.distro_finder_cls)
+        install_root = resolver.site.downloads["install_root"]
+
+        for di in a_distro_finder.versions.values():
+            # Get the downloadable distro
+            with resolver.distro_mode_override(DistroMode.Downloaded):
+                dl_distro = resolver.find_distro(f"{di.name}=={di.version}")
+
+            # Ensure the finder used to create this distro is set
+            assert dl_distro.finder == dl_finder
+
+            dest = install_root / dl_distro.distro_name / str(dl_distro.version)
+            assert not dest.exists()
+            dl_finder.install(dl_distro.filename, dest)
+            assert dest.is_dir()
+            assert (dest / ".hab.json").exists()
+            assert (dest / "file_a.txt").exists()
+            assert (dest / "folder/file_b.txt").exists()
+
+            # Test that if you try to install an already existing distro
+            # an exception is raised
+            with pytest.raises(
+                InstallDestinationExistsError, match="The destination already exists:"
+            ) as excinfo:
+                dl_finder.install(dl_distro.filename, dest)
+            assert excinfo.value.filename == dest
+
+    def check_resolver_install(self, a_distro_finder, helpers, tmp_path, caplog):
+        resolver = self.create_resolver(a_distro_finder.zip_root, helpers, tmp_path)
+        # NOTE: The `Resolver.install` method defaults dry_run to True so code
+        # developers have to opt into actually installing.
+        install_root = resolver.site.downloads["install_root"]
+        # This dir won't exist until the first non-dry_run install is run.
+        assert not install_root.exists()
+
+        # Build testing URI config files.
+        config_root = tmp_path / "configs"
+        config_root.mkdir()
+        with (config_root / "proj_1.json").open("w") as fle:
+            json.dump(dict(name="proj_1", distros=["dist_a", "dist_b"]), fle, indent=4)
+
+        # Check that an error is raised if install_root is not set and target
+        # is not specified
+        resolver.site.downloads.pop("install_root")
+        with pytest.raises(HabError, match=r"You must specify target,"):
+            resolver.install(target=None)
+        resolver.site.downloads["install_root"] = install_root
+
+        # Check only specifying distros, and that they processed in a single resolve
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="hab.resolver"):
+            missing = resolver.install(additional_distros=["dist_a", "dist_a==0.1"])
+        assert len(missing) == 1
+        assert isinstance(missing[0], LazyDistroVersion)
+        assert missing[0].name == "dist_a==0.1"
+        # Check the dry_run mode logging output
+        assert caplog.record_tuples == [
+            (
+                "hab.resolver",
+                logging.WARNING,
+                "Dry Run would install distros: dist_a==0.1",
+            ),
+        ]
+
+        with pytest.raises(InvalidRequirementError):
+            resolver.install(additional_distros=["dist_a==0.2", "dist_a==0.1"])
+
+        # Ensure the above installs were all in dry_run mode.
+        assert not install_root.exists()
+
+        # Check dry_run=False actually installs a distro
+        caplog.clear()
+        missing = resolver.install(additional_distros=["dist_a==0.1"], dry_run=False)
+        assert (install_root / "dist_a" / "0.1" / ".hab.json").is_file()
+        assert (install_root / "dist_a" / "0.1" / "file_a.txt").is_file()
+        assert caplog.record_tuples == [
+            ("hab.resolver", logging.WARNING, "Installing distros: dist_a==0.1"),
+            ("hab.resolver", logging.WARNING, "Installing distro: dist_a==0.1"),
+            ("hab.resolver", logging.WARNING, "Installed distros: dist_a==0.1"),
+        ]
+
+        # Test passing a URI. This uri doesn't specify a version for dist_a so the
+        # newer dist_a==1.0 is installed along side the latest dist_b==0.6.
+        caplog.clear()
+        missing = resolver.install(uris=["proj_1"], dry_run=False)
+        assert (install_root / "dist_a" / "0.1" / ".hab.json").is_file()
+        assert (install_root / "dist_a" / "0.1" / "file_a.txt").is_file()
+        assert (install_root / "dist_a" / "1.0" / ".hab.json").is_file()
+        assert (install_root / "dist_a" / "1.0" / "file_a.txt").is_file()
+        assert (install_root / "dist_b" / "0.6" / ".hab.json").is_file()
+        assert (install_root / "dist_b" / "0.6" / "file_a.txt").is_file()
+        assert caplog.record_tuples == [
+            (
+                "hab.resolver",
+                logging.WARNING,
+                "Installing distros: dist_a==1.0, dist_b==0.6",
+            ),
+            ("hab.resolver", logging.WARNING, "Installing distro: dist_a==1.0"),
+            ("hab.resolver", logging.WARNING, "Installing distro: dist_b==0.6"),
+            (
+                "hab.resolver",
+                logging.WARNING,
+                "Installed distros: dist_a==1.0, dist_b==0.6",
+            ),
+        ]
+
+    def check_resolver_install_kwargs(
+        self, a_distro_finder, kwargs, installed, helpers, tmp_path, caplog
+    ):
+        resolver = self.create_resolver(a_distro_finder.zip_root, helpers, tmp_path)
+
+        configs = [
+            {"name": "proj_1", "distros": ["dist_a", "dist_b"]},
+            {"name": "proj_2", "distros": ["dist_a==0.2", "dist_b==0.5"]},
+            {"name": "proj_3", "distros": []},
+        ]
+
+        # Build testing URI config files.
+        config_root = tmp_path / "configs"
+        config_root.mkdir()
+        for config in configs:
+            with (config_root / f"{config['name']}.json").open("w") as fle:
+                json.dump(config, fle, indent=4)
+
+        kwargs["dry_run"] = False
+        missing = resolver.install(**kwargs)
+        names = sorted([distro.name for distro in missing])
+        assert names == installed
+
+    def check_resolver_install_replace(
+        self, a_distro_finder, helpers, tmp_path, caplog
+    ):
+        resolver = self.create_resolver(a_distro_finder.zip_root, helpers, tmp_path)
+        install_root = resolver.site.downloads["install_root"]
+        data_txt = install_root / "dist_a" / "1.0" / "data.txt"
+        file_a = install_root / "dist_a" / "1.0" / "file_a.txt"
+        file_a_text = "File A inside the distro."
+
+        # Install the distro
+        resolver.install(dry_run=False, additional_distros=["dist_a==1.0"])
+        assert file_a.open("r").read() == file_a_text
+
+        # Simulate this version being modified locally or is some how out of date.
+        with file_a.open("w") as fle:
+            fle.write("Modified text")
+        data_txt.unlink()
+
+        # With replace as False, the distro is not modified and is not returned.
+        missing = resolver.install(dry_run=False, additional_distros=["dist_a==1.0"])
+        assert missing == []
+        assert file_a.open("r").read() == "Modified text"
+        assert not data_txt.exists()
+
+        # With replace enabled, the distro is removed from disk, re-installed
+        # and returned as a missing distro.
+        missing = resolver.install(
+            replace=True, dry_run=False, additional_distros=["dist_a==1.0"]
+        )
+        assert [d.name for d in missing] == ["dist_a==1.0"]
+        assert file_a.open("r").read() == file_a_text
+        assert data_txt.exists()
+
+    def check_resolver_install_existing(
+        self, a_distro_finder, helpers, tmp_path, caplog
+    ):
+        """Check installing additional versions of a distro.
+
+        If a distro has another version installed but that doesn't match the
+        install requirements, a suitable distro is resolved and installed as well.
+        """
+        resolver = self.create_resolver(a_distro_finder.zip_root, helpers, tmp_path)
+        # Install a version of dist_a
+        missing = resolver.install(dry_run=False, additional_distros=["dist_a==1.0"])
+        assert [d.name for d in missing] == ["dist_a==1.0"]
+
+        # Try to install another version of dist_a. This also requires dist_b.
+        missing = resolver.install(dry_run=False, additional_distros=["dist_a==0.2"])
+        assert sorted([d.name for d in missing]) == ["dist_a==0.2", "dist_b==0.6"]
+
+        # Check that all 3 distros are installed.
+        install_root = resolver.site.downloads["install_root"]
+        paths = sorted(install_root.glob("*/*/.hab.json"))
+        check = [
+            install_root / "dist_a" / "0.2" / ".hab.json",
+            install_root / "dist_a" / "1.0" / ".hab.json",
+            install_root / "dist_b" / "0.6" / ".hab.json",
+        ]
+        assert paths == check
+
+        # Uninstall dist_b so we can ensure that it gets re-installed because
+        # dist_a==0.2 requires it.
+        shutil.rmtree(install_root / "dist_b" / "0.6")
+        missing = resolver.install(dry_run=False, additional_distros=["dist_a==0.2"])
+        assert [d.name for d in missing] == ["dist_b==0.6"]
+        assert (install_root / "dist_b" / "0.6" / ".hab.json").exists()
+
+
+class TestDistroFinder(CheckDistroFinder):
+    distro_finder_cls = distro_finder.DistroFinder
+    site_template = "site_distro_finder.json"
+
+    def test_content(self, distro_finder_info):
+        """Content always returns the parent of the provided path currently."""
+        finder = self.distro_finder_cls(distro_finder_info.root)
+        # We may want to improve this later, but it works for now
+        path = distro_finder_info.root / ".hab.json"
+        result = finder.content(path)
+        assert result == distro_finder_info.root
+
+    def test_load_path(self, uncached_resolver):
+        """Currently load_path for DistroFinder just returns None."""
+        finder = distro_finder.DistroFinder("", uncached_resolver.site)
+        assert finder.load_path(Path(".")) is None
+
+    def test_installed(self, distro_finder_info, helpers, tmp_path):
+        self.check_installed(distro_finder_info, helpers, tmp_path)
+
+    def test_install(self, distro_finder_info, helpers, tmp_path):
+        self.check_install(distro_finder_info, helpers, tmp_path)
+
+    def test_clear_cache(self, distro_finder_info):
+        """Cover the clear_cache function, which for this class does nothing."""
+        finder = self.distro_finder_cls(distro_finder_info.root)
+        finder.clear_cache()
+
+
+class TestZipSidecar(CheckDistroFinder):
+    """Tests specific to `DistroFinderZipSidecar`."""
+
+    distro_finder_cls = zip_sidecar.DistroFinderZipSidecar
+    site_template = "site_distro_zip_sidecar.json"
+
+    def test_load_path(self, zip_distro_sidecar):
+        """The Zip Sidecar reads a .json file next to the zip distro.
+
+        Ensure it's able to read data from the .json file.
+        """
+        finder = self.distro_finder_cls(zip_distro_sidecar.root)
+
+        # This distro hard codes the version inside the .json file
+        data = finder.load_path(zip_distro_sidecar.root / "dist_a_v0.1.hab.json")
+        assert data["name"] == "dist_a"
+        assert "distros" not in data
+        assert data["version"] == "0.1"
+
+        # Test a different distro that doesn't hard code the version
+        data = finder.load_path(zip_distro_sidecar.root / "dist_b_v0.5.hab.json")
+        assert data["name"] == "dist_b"
+        assert "distros" not in data
+        assert data["version"] == "0.5"
+
+        # This distro includes required distros
+        data = finder.load_path(zip_distro_sidecar.root / "dist_a_v0.2.hab.json")
+        assert data["name"] == "dist_a"
+        assert data["distros"] == ["dist_b"]
+        assert data["version"] == "0.2"
+
+    def test_installed(self, zip_distro_sidecar, helpers, tmp_path):
+        self.check_installed(zip_distro_sidecar, helpers, tmp_path)
+
+    def test_install(self, zip_distro_sidecar, helpers, tmp_path):
+        self.check_install(zip_distro_sidecar, helpers, tmp_path)
+
+
+class TestZip(CheckDistroFinder):
+    """Tests specific to `DistroFinderZip`."""
+
+    distro_finder_cls = df_zip.DistroFinderZip
+    site_template = "site_distro_zip.json"
+
+    def test_content(self, zip_distro):
+        finder = df_zip.DistroFinderZip(zip_distro.root)
+        # If path is already a .zip file, it is just returned
+        path = zip_distro.root / "already_zip.zip"
+        result = finder.content(path)
+        assert result == path
+
+        # The right most .zip file is returned if path has multiple .zip suffixes.
+        path = zip_distro.root / "a.zip" / "b.zip"
+        result = finder.content(path)
+        assert result == path
+
+        # If a member path is passed, return the right most .zip suffix.
+        member_path = path / ".hab.json"
+        result = finder.content(member_path)
+        assert result == path
+
+        # member paths with nested return the right most .zip suffix.
+        member_path = path / "folder" / "sub-folder" / "file.json"
+        result = finder.content(member_path)
+        assert result == path
+
+        # If no .zip suffix is passed, the original path is returned.
+        path = zip_distro.root / "not_an_archive.txt"
+        result = finder.content(path)
+        assert result == path
+
+    def test_load_path(self, zip_distro):
+        """The Zip finder reads a .json file from inside the zip distro file.
+
+        Ensure it's able to read data from the .json file.
+        """
+        finder = self.distro_finder_cls(zip_distro.root)
+
+        # This distro hard codes the version inside the .json file
+        data = finder.load_path(zip_distro.root / "dist_a_v0.1.zip")
+        assert data["name"] == "dist_a"
+        assert "distros" not in data
+        assert data["version"] == "0.1"
+
+        # Test a different distro that doesn't hard code the version
+        data = finder.load_path(zip_distro.root / "dist_b_v0.5.zip")
+        assert data["name"] == "dist_b"
+        assert "distros" not in data
+        assert data["version"] == "0.5"
+
+        # This distro includes required distros
+        data = finder.load_path(zip_distro.root / "dist_a_v0.2.zip")
+        assert data["name"] == "dist_a"
+        assert data["distros"] == ["dist_b"]
+        assert data["version"] == "0.2"
+
+    def test_zip_get_file_data(self, zip_distro, caplog):
+        """Test edge cases for `DistroFinderZip.get_file_data`."""
+        finder = df_zip.DistroFinderZip(zip_distro.root)
+        assert finder._cache == {}
+
+        # This file doesn't have a .hab.json file inside it
+        path = zip_distro.root / "not_valid_v0.1.zip"
+        data = finder.get_file_data(path)
+        assert data is None
+        assert [path / ".hab.json"] == list(finder._cache.keys())
+        finder.clear_cache()
+
+        # Check what happens if a member path isn't provided(Just the .zip file path)
+        path = zip_distro.root / "dist_a_v0.1.zip"
+        member_path = path / ".hab.json"
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger="hab.distro_finders.df_zip"):
+            data = finder.get_file_data(path)
+        check = [f'Implicitly added member ".hab.json" to path "{member_path}".']
+        assert check == [rec.message for rec in caplog.records]
+        # The raw data text was read and returned
+        assert data == b'{\n    "name": "dist_a",\n    "version": "0.1"\n}'
+        assert member_path in finder._cache
+
+        # Test that the cache is returned if populated
+        data = "Data already in the cache"
+        finder._cache[Path(member_path)] = data
+        assert finder.get_file_data(member_path) is data
+
+    def test_installed(self, zip_distro, helpers, tmp_path):
+        self.check_installed(zip_distro, helpers, tmp_path)
+
+    def test_install(self, zip_distro, helpers, tmp_path):
+        self.check_install(zip_distro, helpers, tmp_path)
+
+    def test_clear_cache(self, distro_finder_info):
+        """Test the clear_cache function for this class."""
+        finder = self.distro_finder_cls(distro_finder_info.root)
+        finder._cache["test"] = "case"
+        finder.clear_cache()
+        assert finder._cache == {}
+
+    def test_resolver_install(self, zip_distro, helpers, tmp_path, caplog):
+        """Test the bulk of the `Resolver.install` method."""
+        self.check_resolver_install(zip_distro, helpers, tmp_path, caplog)
+
+    @pytest.mark.parametrize(
+        "kwargs,installed",
+        (
+            (
+                {"uris": ["proj_1"]},
+                ["dist_a==1.0", "dist_b==0.6"],
+            ),
+            (
+                {"uris": ["proj_1", "proj_2"]},
+                ["dist_a==0.2", "dist_a==1.0", "dist_b==0.5", "dist_b==0.6"],
+            ),
+            (
+                {"uris": ["proj_1"], "additional_distros": ["dist_b==0.5"]},
+                ["dist_a==1.0", "dist_b==0.5", "dist_b==0.6"],
+            ),
+            (
+                {"uris": ["proj_3"]},
+                [],
+            ),
+            (
+                {"uris": ["proj_3"], "additional_distros": ["dist_b"]},
+                ["dist_b==0.6"],
+            ),
+        ),
+    )
+    def test_resolver_install_kwargs(
+        self, zip_distro, kwargs, installed, helpers, tmp_path, caplog
+    ):
+        """Test how various `Resolver.install` inputs are resolved"""
+        self.check_resolver_install_kwargs(
+            zip_distro, kwargs, installed, helpers, tmp_path, caplog
+        )
+
+    def test_resolver_install_replace(self, zip_distro, helpers, tmp_path, caplog):
+        """Test the replace feature of `Resolver.install`.
+
+        Verifies that already installed distros are ignored unless replace is True.
+        """
+        self.check_resolver_install_replace(zip_distro, helpers, tmp_path, caplog)
+
+    def test_resolver_install_existing(self, zip_distro, helpers, tmp_path, caplog):
+        """Test the replace feature of `Resolver.install`.
+
+        Verifies that already installed distros are ignored unless replace is True.
+        """
+        self.check_resolver_install_existing(zip_distro, helpers, tmp_path, caplog)
+
+
+# These tests only work if using the `pyXX-s3` tox testing env
+@pytest.mark.skipif(
+    not os.getenv("VIRTUAL_ENV", "").endswith("-s3"),
+    reason="not testing optional s3 cloud",
+)
+class TestS3(CheckDistroFinder):
+    """Tests specific to `DistroFinderS3Zip`.
+
+    Note: All tests should use the `zip_distro_s3` fixture. This ensures that
+    any s3 requests are local and also speeds up the test.
+    """
+
+    site_template = "site_distro_s3.json"
+
+    class ServerSimulator:
+        """Requests server used for testing downloading a partial zip file.
+
+        Based on remotezip test code:
+        https://github.com/gtsystem/python-remotezip/blob/master/test_remotezip.py
+        """
+
+        def __init__(self, fname):
+            self._fname = fname
+            self.requested_ranges = []
+
+        def serve(self, request, context):
+            import remotezip
+
+            from_byte, to_byte = remotezip.RemoteFetcher.parse_range_header(
+                request.headers["Range"]
+            )
+            self.requested_ranges.append((from_byte, to_byte))
+
+            with open(self._fname, "rb") as f:
+                if from_byte < 0:
+                    f.seek(0, 2)
+                    size = f.tell()
+                    f.seek(max(size + from_byte, 0), 0)
+                    init_pos = f.tell()
+                    content = f.read(min(size, -from_byte))
+                else:
+                    f.seek(from_byte, 0)
+                    init_pos = f.tell()
+                    content = f.read(to_byte - from_byte + 1)
+
+            context.headers[
+                "Content-Range"
+            ] = remotezip.RemoteFetcher.build_range_header(
+                init_pos, init_pos + len(content)
+            )
+            return content
+
+    @property
+    def distro_finder_cls(self):
+        """Only import this class if the test is not skipped."""
+        from hab.distro_finders.s3_zip import DistroFinderS3Zip
+
+        return DistroFinderS3Zip
+
+    def test_load_path(self, zip_distro_s3, helpers, tmp_path, requests_mock):
+        """Simulate reading only part of a remote zip file hosted in an aws s3 bucket.
+
+        This doesn't actually connect to an aws s3 bucket, it uses mock libraries
+        to simulate the process.
+        """
+        import boto3
+
+        if sys.version_info.minor <= 7:
+            # NOTE: boto3 has dropped python 3.7. Moto changed their context name
+            # when they dropped support for python 3.7.
+            from moto import mock_s3 as mock_aws
+        else:
+            from moto import mock_aws
+
+        # Make requests connect to a simulated s3 server that supports the range header
+        server = self.ServerSimulator(
+            zip_distro_s3.zip_root / "hab-test-bucket" / "dist_a_v0.1.zip"
+        )
+        requests_mock.register_uri(
+            "GET",
+            "s3://hab-test-bucket/dist_a_v0.1.zip",
+            content=server.serve,
+            status_code=200,
+        )
+
+        # Create a mock aws setup using moto to test the authorization code
+        resolver = self.create_resolver(zip_distro_s3.zip_root, helpers, tmp_path)
+        dl_finder = resolver.site.downloads["distros"][0]
+
+        with mock_aws():
+            # The LocalS3Client objects don't have all of the s3 properties we
+            # require for configuring requests auth. Add them and crate the bucket.
+            sess = boto3.Session(region_name="us-east-2")
+            conn = boto3.resource("s3", region_name="us-east-2")
+            conn.create_bucket(
+                Bucket="hab-test-bucket",
+                CreateBucketConfiguration={"LocationConstraint": "us-east-2"},
+            )
+            dl_finder.client.sess = sess
+            dl_finder.client.client = sess.client("s3", region_name="us-east-2")
+
+            # Test reading .hab.json from inside a remote .zip file.
+            dl_finder = resolver.site.downloads["distros"][0]
+            zip_path = dl_finder.root / "dist_a_v0.1.zip"
+            archive = dl_finder.archive(zip_path)
+
+            # Check that the filename property is always populated
+            assert str(archive.filename) == str(zip_path)
+
+            # Check that we were able to read the data from the archive
+            data = dl_finder.load_path(zip_path / ".hab.json")
+            assert data["name"] == "dist_a"
+            assert data["version"] == "0.1"
+
+        # Verify that remotezip had to make more than one request. This is because
+        # the .zip file is larger than `initial_buffer_size`.
+        assert len(server.requested_ranges) == 2
+
+    def test_installed(self, zip_distro_s3, helpers, tmp_path):
+        self.check_installed(zip_distro_s3, helpers, tmp_path)
+
+    def test_install(self, zip_distro_s3, helpers, tmp_path):
+        self.check_install(zip_distro_s3, helpers, tmp_path)
+
+    def test_client(self, zip_distro_s3, helpers, tmp_path):
+        """Test `DistroFinderS3Zip.client` edge cases."""
+        default_cache_dir = utils.Platform.default_download_cache()
+        # Test if `site.downloads["cache_root"]` is not set
+        finder = self.distro_finder_cls("s3://hab-test-bucket")
+        assert finder.client._local_cache_dir == default_cache_dir
+
+        # Test if `site.downloads["cache_root"]` is set
+        resolver = self.create_resolver(zip_distro_s3.root, helpers, tmp_path)
+        finder = self.distro_finder_cls("s3://hab-test-bucket", site=resolver.site)
+        cache_dir = resolver.site["downloads"]["cache_root"]
+        assert finder.client._local_cache_dir == cache_dir
+
+        # Test the client setter
+        finder.client = "A custom client"
+        assert finder.client == "A custom client"
+
+        # Test init with a custom client
+        from cloudpathlib.local import LocalS3Client
+
+        client = LocalS3Client()
+        finder = self.distro_finder_cls("s3://hab-test-bucket", client=client)
+        assert finder.client == client
+
+    def test_as_posix(self, zip_distro_s3):
+        """Cloudpathlib doesn't support `as_posix` a simple str is returned."""
+        # Test that as_posix for CloudPath's returns the CloudPath as a str
+        finder = self.distro_finder_cls("s3://hab-test-bucket")
+        assert finder.as_posix() == "s3://hab-test-bucket"
+
+        # Otherwise it returns a standard pathlib.Path.as_posix value
+        finder.root = zip_distro_s3.root
+        assert finder.as_posix() == zip_distro_s3.root.as_posix()
+
+    def test_clear_cache(self, zip_distro_s3):
+        """Test the clear_cache function for this class."""
+
+        class Archive:
+            """Simulated ZipFile class to test that open archives get closed."""
+
+            def __init__(self):
+                self.is_open = True
+
+            def close(self):
+                self.is_open = False
+
+        class Client:
+            """Simulated S3Client to test calling clear_cache on."""
+
+            def __init__(self):
+                self.cleared = False
+
+            def clear_cache(self):
+                self.cleared = True
+
+        finder = self.distro_finder_cls("s3://hab-test-bucket")
+        # Simulate use of the finder
+        archive = Archive()
+        finder._archives["s3://hab-test-bucket/dist_a_v0.1.zip"] = archive
+        finder._cache["test"] = "case"
+        finder.client = Client()
+        assert archive.is_open
+        assert not finder.client.cleared
+
+        # Check that clearing reset the cache variables
+        finder.clear_cache()
+        assert finder._archives == {}
+        assert finder._cache == {}
+        # Check that any open archives were closed
+        assert not archive.is_open
+        # Check that the client was not cleared as persistent is False
+        assert not finder.client.cleared
+
+        # Clearing of persistent caches clears the cache
+        finder.clear_cache(persistent=True)
+        assert finder.client.cleared
+
+
+# TODO: Break this into separate smaller tests of components for each class not this
+@pytest.mark.parametrize(
+    "distro_info",
+    (
+        # "distro_finder_info",
+        "zip_distro",
+        "zip_distro_sidecar",
+    ),
+)
+def dtest_zip(request, distro_info, helpers, tmp_path):
+    # Convert the distro_info parameter to testing values.
+    df_cls = df_zip.DistroFinderZip
+    hab_json = ".hab.json"
+    implements_cache = True
+    parent_type = True
+    site_filename = "site_distro_zip.json"
+    if distro_info == "zip_distro_sidecar":
+        df_cls = zip_sidecar.DistroFinderZipSidecar
+        hab_json = "{name}_v{ver}.hab.json"
+        implements_cache = False
+        parent_type = "sidecar"
+        site_filename = "site_distro_zip_sidecar.json"
+    elif distro_info == "distro_finder_info":
+        df_cls = distro_finder.DistroFinder
+        implements_cache = False
+        parent_type = "directory"
+        site_filename = "site_distro_finder.json"
+    distro_info = request.getfixturevalue(distro_info)
+
+    site_file = tmp_path / "site.json"
+    helpers.render_template(
+        site_filename, site_file, zip_root=distro_info.root.as_posix()
+    )
+    site_distros = tmp_path / "distros"
+
+    check = set([v[:2] for v in distro_info.versions])
+
+    site = Site([site_file])
+    resolver = Resolver(site)
+    results = set()
+    # The correct class was resolved
+    df = resolver.distro_paths[0]
+    assert type(df) == df_cls
+
+    if implements_cache:
+        assert df._cache == {}
+
+    for node in resolver.dump_forest(resolver.distros, attr=None):
+        distro = node.node
+        if not isinstance(distro, DistroVersion):
+            continue
+
+        # Ensure the finder used to create this distro is set
+        assert distro.finder == df
+
+        assert distro.filename.name == hab_json.format(
+            name=distro.distro_name, ver=distro.version
+        )
+        if parent_type == "zip":
+            # If the parent is a zip, then the parent is a zip file
+            assert distro.filename.parent.suffix == ".zip"
+            assert distro.filename.parent.is_file()
+        elif parent_type == "sidecar":
+            # There is a sidecar zip file next to the *.hab.json file
+            zip_filename = distro.filename.name.replace(".hab.json", ".zip")
+            assert (distro.filename.parent / zip_filename).is_file()
+        elif parent_type == "directory":
+            assert distro.filename.is_file()
+            assert distro.filename.name == ".hab.json"
+
+        if implements_cache:
+            assert distro.filename in df._cache
+
+        results.add((distro.distro_name, str(distro.version)))
+
+        # Test the install process extracts all of the files from the zip
+        dest = site_distros / distro.distro_name / str(distro.version)
+        assert not dest.exists()
+        df.install(distro.filename, dest)
+        assert dest.is_dir()
+        assert (dest / ".hab.json").exists()
+        assert (dest / "file_a.txt").exists()
+        assert (dest / "folder/file_b.txt").exists()
+
+        # Test that if you try to install an already existing distro
+        # an exception is raised
+        with pytest.raises(
+            InstallDestinationExistsError, match="The destination already exists:"
+        ) as excinfo:
+            df.install(distro.filename, dest)
+        assert excinfo.value.filename == dest
+
+        # Test the installed function
+        # Returns True if passed a distro version folder containing a .hab.json
+        assert df.installed(dest)
+        # It returns False if the .hab.json file doesn't exist
+        assert not df.installed(site_distros)
+
+    if implements_cache:
+        df.clear_cache()
+        assert df._cache == {}
+
+    assert results == check

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -220,7 +220,7 @@ class TestCliExitCodes:
 
     @pytest.mark.skipif(sys.platform != "win32", reason="only applies on windows")
     @missing_annotations_hack
-    def test_bat(self, config_root, exit_code):
+    def test_bat(self, config_root, exit_code, tmp_path):
         hab_bin = (config_root / ".." / "bin" / "hab.bat").resolve()
         # fmt: off
         cmd = [
@@ -230,8 +230,13 @@ class TestCliExitCodes:
         ]
         # fmt: on
 
+        # When running tox in parallel we may run into the `%RANDOM%` collision.
+        # Change the `TMP` env var to a per-test unique folder to avoid this.
+        env = os.environ.copy()
+        env["TMP"] = str(tmp_path)
+
         # Run the hab command in a subprocess
-        proc = subprocess.run(cmd, **self.run_kwargs)
+        proc = subprocess.run(cmd, env=env, **self.run_kwargs)
 
         # Check that the print statement was actually run
         assert proc.stdout == self.output_text

--- a/tests/test_lazy_distro_version.py
+++ b/tests/test_lazy_distro_version.py
@@ -1,0 +1,151 @@
+import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+from hab import DistroMode
+from hab.errors import InstallDestinationExistsError
+from hab.parsers.lazy_distro_version import DistroPath, LazyDistroVersion
+
+
+def test_distro_path(zip_distro_sidecar, helpers, tmp_path):
+    resolver = helpers.render_resolver(
+        "site_distro_zip_sidecar.json",
+        tmp_path,
+        zip_root=zip_distro_sidecar.root.as_posix(),
+    )
+    with resolver.distro_mode_override(DistroMode.Downloaded):
+        distro = resolver.find_distro("dist_a==0.2")
+
+    # Passing root as a string converts it to a pathlib.Path object.
+    dpath = DistroPath(
+        distro, str(tmp_path), relative="{distro_name}-v{version}", site=resolver.site
+    )
+    # Test that the custom relative string, it used to generate root
+    assert dpath.root == tmp_path / "dist_a-v0.2"
+    assert dpath.hab_filename == tmp_path / "dist_a-v0.2" / ".hab.json"
+
+    # If site and relative are not passed the default is used
+    dpath = DistroPath(distro, tmp_path)
+    assert dpath.root == tmp_path / "dist_a" / "0.2"
+    assert dpath.hab_filename == tmp_path / "dist_a" / "0.2" / ".hab.json"
+
+    # Test that site settings are respected when not passing relative
+    resolver.site.downloads["relative_path"] = "parent/{distro_name}/child/{version}"
+    dpath = DistroPath(distro, tmp_path, site=resolver.site)
+    assert dpath.root == tmp_path / "parent" / "dist_a" / "child" / "0.2"
+    assert (
+        dpath.hab_filename
+        == tmp_path / "parent" / "dist_a" / "child" / "0.2" / ".hab.json"
+    )
+
+
+def test_is_lazy(zip_distro_sidecar, helpers, tmp_path):
+    """Check that a LazyDistroVersion doesn't automatically load all data."""
+    resolver = helpers.render_resolver(
+        "site_distro_zip_sidecar.json",
+        tmp_path,
+        zip_root=zip_distro_sidecar.root.as_posix(),
+    )
+    with resolver.distro_mode_override(DistroMode.Downloaded):
+        distro = resolver.find_distro("dist_a==0.1")
+
+    frozen_data = dict(
+        context=["dist_a"],
+        name="dist_a==0.1",
+        version=Version("0.1"),
+    )
+    filename = zip_distro_sidecar.root / "dist_a_v0.1.hab.json"
+
+    # The find_distro call should have called load but does not actually load data
+    assert isinstance(distro, LazyDistroVersion)
+    assert distro._loaded is False
+    assert distro.context == ["dist_a"]
+    assert distro.filename == filename
+    assert distro.frozen_data == frozen_data
+    assert distro.name == "dist_a==0.1"
+
+    # Calling _ensure_loaded actually loads the full distro from the finder's data
+    data = distro._ensure_loaded()
+    assert distro._loaded is True
+    assert isinstance(data, dict)
+    assert distro.name == "dist_a==0.1"
+
+    # If called a second time, then nothing extra is done and no data is returned.
+    assert distro._ensure_loaded() is None
+
+
+def test_bad_kwargs():
+    """Test that the proper error is raised if you attempt to init with a filename."""
+    match = "Passing filename to this class is not supported."
+    with pytest.raises(ValueError, match=match):
+        LazyDistroVersion(None, None, "filename")
+
+    with pytest.raises(ValueError, match=match):
+        LazyDistroVersion(None, None, filename="a/filename")
+
+
+@pytest.mark.parametrize(
+    "prop,check",
+    (("distros", {"dist_b": Requirement("dist_b")}),),
+)
+def test_lazy_hab_property(prop, check, zip_distro_sidecar, helpers, tmp_path):
+    """Check that a LazyDistroVersion doesn't automatically load all data."""
+    resolver = helpers.render_resolver(
+        "site_distro_zip_sidecar.json",
+        tmp_path,
+        zip_root=zip_distro_sidecar.root.as_posix(),
+    )
+    with resolver.distro_mode_override(DistroMode.Downloaded):
+        distro = resolver.find_distro("dist_a==0.2")
+
+    # Calling a lazy getter ensures the data is loaded
+    assert distro._loaded is False
+    value = getattr(distro, prop)
+    assert distro._loaded is True
+    assert value == check
+
+    # You can call the lazy getter repeatedly
+    value = getattr(distro, prop)
+    assert value == check
+
+
+def test_install(zip_distro_sidecar, helpers, tmp_path):
+    """Check that a LazyDistroVersion doesn't automatically load all data."""
+    resolver = helpers.render_resolver(
+        "site_distro_zip_sidecar.json",
+        tmp_path,
+        zip_root=zip_distro_sidecar.root.as_posix(),
+    )
+    with resolver.distro_mode_override(DistroMode.Downloaded):
+        distro = resolver.find_distro("dist_a==0.2")
+    dest_root = resolver.site.downloads["install_root"]
+    distro_root = dest_root / "dist_a" / "0.2"
+    hab_json = distro_root / ".hab.json"
+
+    # The distro is not currently installed. This also tests that it can
+    # auto-cast to DistroPath
+    assert not distro.installed(dest_root)
+
+    # Install will clear the cache, ensure its populated
+    assert resolver._downloadable_distros is not None
+    # Install the distro using LazyDistroVersion
+    distro.install(dest_root)
+    assert distro.installed(dest_root)
+    assert hab_json.exists()
+    # Check that the cache was cleared by the install function
+    assert resolver._downloadable_distros is None
+
+    # Test that if the distro is already installed, an error is raised
+    with pytest.raises(InstallDestinationExistsError) as excinfo:
+        distro.install(dest_root)
+    assert excinfo.value.filename == distro_root
+
+    # Test forced replacement of an existing distro by creating an extra file
+    extra_file = distro_root / "extra_file.txt"
+    extra_file.touch()
+    # This won't raise the exception, but will remove the old distro
+    distro.install(dest_root, replace=True)
+    assert hab_json.exists()
+    assert distro.installed(dest_root)
+
+    assert not extra_file.exists()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,5 @@
 import os
 import pathlib
-import sys
 from collections import OrderedDict
 from pathlib import Path
 
@@ -573,13 +572,7 @@ class TestResolveRequirements:
             # Ensure this is a deepcopy of forced and ensure the values are equal
             assert resolver_forced.__forced_requirements__ is not forced
             for k, v in resolver_forced.__forced_requirements__.items():
-                if sys.version_info.minor == 6:
-                    # NOTE: packaging>22.0 doesn't support equal checks for Requirement
-                    # objects. Python 3.6 only has a 21 release, so we have to compare str
-                    # TODO: Once we drop py3.6 support drop this if statement
-                    assert str(forced[k]) == str(v)
-                else:
-                    assert forced[k] == v
+                assert forced[k] == v
                 assert forced[k] is not v
 
         # Check that forced_requirements work if the config defines zero distros

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = begin,py{36,37,38,39,310,311}-{json,json5},end,black,flake8
+envlist = begin,py{37,38,39,310,311}-{json,json5},end,black,flake8
 skip_missing_interpreters = True
 skipsdist = True
 
@@ -29,14 +29,14 @@ commands =
 
     coverage erase
 
-[testenv:py{36,37,38,39,310,311}-{json,json5}]
+[testenv:py{37,38,39,310,311}-{json,json5}]
 depends = begin
 
 [testenv:end]
 basepython = python3
 depends =
     begin
-    py{36,37,38,39,310,311}-{json,json5}
+    py{37,38,39,310,311}-{json,json5}
 parallel_show_output = True
 deps =
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,15 @@ commands =
 
     coverage erase
 
+[testenv:py{36,37,38,39,310,311}-{json,json5}]
+depends = begin
+
 [testenv:end]
 basepython = python3
+depends =
+    begin
+    py{36,37,38,39,310,311}-{json,json5}
+parallel_show_output = True
 deps =
     coverage
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = begin,py{37,38,39,310,311}-{json,json5},end,black,flake8
+envlist = begin,py{37,38,39,310,311}-{json,json5,s3},end,black,flake8
 skip_missing_interpreters = True
 skipsdist = True
 
@@ -15,6 +15,9 @@ deps =
     coverage
     pytest
     json5: pyjson5
+    s3: .[s3]
+    s3: moto[s3]
+    s3: requests-mock
 commands =
     coverage run -m pytest {tty:--color=yes} {posargs:tests/}
 
@@ -36,7 +39,7 @@ depends = begin
 basepython = python3
 depends =
     begin
-    py{37,38,39,310,311}-{json,json5}
+    py{37,38,39,310,311}-{json,json5,s3}
 parallel_show_output = True
 deps =
     coverage


### PR DESCRIPTION
Add the cli command `hab install`. This resolves the required distros for multiple URI's against a remote download server, downloads and installs any missing distros.

This also re-works how distros are resolved into a DistroFinder class or subclasses. These can be used to customize how distros are resolved by hab. This includes resolving distros from aws s3 buckets.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
