### PR TITLE
`WinPlatform.normalize_path` no longer changes the UNC drive case

### DIFF
--- a/hab/utils.py
+++ b/hab/utils.py
@@ -581,7 +581,8 @@ class WinPlatform(BasePlatform):
 
         This ensures that the drive letter is resolved consistently to uppercase.
         """
-        if not path.is_absolute():
+        # Don't change the case of relative or UNC paths
+        if not path.is_absolute() or ":" not in path.drive:
             return path
         parts = path.parts
         cls = type(path)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -851,8 +851,12 @@ class TestPlatform:
             # the drive letter is always upper-cased if specified
             (r"c:\temp", "C:/temp"),
             (r"C:\temp", "C:/temp"),
+            (r"C:\teMP", "C:/teMP"),
             (r"z:\subfolder", "Z:/subfolder"),
             (r"relative\path", "relative/path"),
+            # UNC file paths do not have case changed
+            (r"\\unc\share\folder", "//unc/share/folder"),
+            (r"\\UnC\shaRe\folDer", "//UnC/shaRe/folDer"),
         ),
     )
     def test_normalize_path_windows(self, path, check):


### PR DESCRIPTION
The previous commit didn't take into account UNC file path and would uppercase the `\\server\share` which was unintentional and should be avoided.

UNC file paths are now left unchanged. This lets the site file manage the case of unc paths and ensures the `platform_path_maps` feature is applied consistently.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
