### PR TITLE
Prevent hab env from exiting if any errors happen in the child shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,12 @@ Examples of running specific tests:
 - `tox -e flake8`  Run the flake8 tests
 - `tox -e begin,py37-json,end -- -vv`  Enables verbose mode for pytest. Any text after `--` is passed as cli arguments passed to pytest
 
+# Manual testing
+
+The majority of testing is done using tox and pytest, however there are a few tests
+that we haven't been able to get working automatically.
+See [tests/manual/README.md](tests/manual/README.md) for details.
+
 # Overview
 
 ## URI

--- a/hab/templates/config.sh
+++ b/hab/templates/config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[{{ hab_cfg.uri }}] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 {% for key, value in hab_cfg.environment.items() %}
@@ -59,12 +76,16 @@ export -f {{ alias }};
 
 {% endfor %}
 {% endif %}
-
 {% if launch_info %}
+
 # Run the requested command
 {{ launch_info.key }}{{ launch_info.args }}
 {% endif %}
-
 {% if exit and create_launch %}
+
 exit
 {% endif %}
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -1,0 +1,18 @@
+# Manual tests
+
+There are some tests that we haven't been able to get working automatically via pytest.
+These scripts should be manually run in the correct shell and platform and the output
+verified.
+
+# test_env.sh
+
+This tests the `hab env` command in bash on both windows and linux. Follow the
+instructions printed when running the script and verify the output of each command
+run.
+
+# test_launch.sh
+
+This tests the `hab launch` command in bash on both windows and linux. This test
+requires no user input but won't run when called by pytest. You should see it test
+several exit codes and is only considered successful if you see the final message
+printed `'hab launch' testing completed successfully.`

--- a/tests/manual/test_env.sh
+++ b/tests/manual/test_env.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# This script is a workaround for not being able to call `hab launch`` and `hab env`
+# automatically from using subprocess in pytest. The developer should manually
+# run this script and verify that all steps can be completed successfully.
+
+# Hab will always output this text for the command we are calling
+EXPECTED_OUTPUT="Running...
+<module 'sys' (built-in)>"
+
+# Configure hab
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export HAB_PATHS="$SCRIPT_DIR/../site_main.json"
+
+RED='\033[0;31m'
+GRN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Guide the dev through the testing process
+echo "Manual test of hab env. Manyally run the following commands and verify the output."
+echo -e "Text in ${RED}red${NC} should be copied into a prompt and run."
+echo -e "Text in ${GRN}green${NC} is the output from running the command."
+echo -e "Until noted you should always see '[app/aliased]' as part of the shell's prompt. If this goes away the test is a failure."
+echo "1. Check the shell options managed by the 'set' command."
+echo -e "$ ${RED}echo \$-${NC}"
+echo -e "You should see something like ${GRN}himBHs${NC}. Verify that it doesn't contain ${GRN}e${NC}."
+echo "2. Verify that causing a error in bash doesn't exit the hab env."
+echo -e "$ ${RED}something-not-valid${NC}"
+echo -e "${GRN}bash: something-not-valid: command not found${NC}"
+echo "3. Run the as_str alias which calls python and runs a command."
+echo -e "$ ${RED}as_str -c \"import sys;print(sys);sys.exit(5)\"${NC}"
+echo -e "${GRN}<module 'sys' (built-in)>${NC}"
+echo "Verify that the expected return code was returned."
+echo -e "$ ${RED}echo \$?${NC}"
+echo -e "${GRN}5${NC}"
+echo "4. Check no error return code is respected"
+echo -e "$ ${RED}as_str -c \"import sys;print(sys);sys.exit(0)\"${NC}"
+echo -e "${GRN}<module 'sys' (built-in)>${NC}"
+echo -e "$ ${RED}echo \$?${NC}"
+echo -e "${GRN}0${NC}"
+echo "Exit the hab env sub-shell. This removes '[app/aliased]' from the prompt."
+echo -e "$ ${RED}exit${NC}"
+hab env app/aliased

--- a/tests/manual/test_launch.sh
+++ b/tests/manual/test_launch.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Hab will always output this text for the command we are calling
+EXPECTED_OUTPUT="Running...
+<module 'sys' (built-in)>"
+
+# Configure hab
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export HAB_PATHS="$SCRIPT_DIR/../site_main.json"
+
+# Call hab launch and ensure the correct output and exit code are generated
+validate_output() {
+    local expected_exit_code=$1
+
+    echo "Testing exit code: $expected_exit_code"
+
+    # Run the command and capture the output and exit code
+    output=$(hab launch app/aliased as_str -c \
+        "print('Running...');import sys;print(sys);sys.exit($expected_exit_code)")
+    exit_code=$?
+
+    # Check if the return code matches the expected value
+    if [[ $exit_code -ne $expected_exit_code ]]; then
+        echo "Error: 'hab launch' failed with exit code $exit_code != $expected_exit_code"
+        exit 1
+    fi
+
+    # On windows strip out \r characters
+    output=$(echo "$output" | sed -e 's/\r//g')
+
+    # Check if the output matches the expected text
+    if [[ "$output" != "$EXPECTED_OUTPUT" ]]; then
+        echo "Error: Unexpected output from 'hab launch'"
+        echo "Expected: ***********************"
+        echo "$EXPECTED_OUTPUT" | cat -e
+        echo "Generated: ***********************"
+        echo "$output" | cat -e
+        echo "***********************"
+        exit 1
+    fi
+}
+
+validate_output 5
+validate_output 4
+validate_output 0
+
+echo "'hab launch' testing completed successfully."

--- a/tests/reference_scripts/sh_linux_activate/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_activate/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -112,3 +129,8 @@ function pip() {
     /usr/local/bin/mayapy2020 -m pip "$@";
 }
 export -f pip;
+
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/reference_scripts/sh_linux_activate_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_activate_launch/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -116,3 +133,7 @@ export -f pip;
 
 # Run the requested command
 pip
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/reference_scripts/sh_linux_env/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_env/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -112,3 +129,8 @@ function pip() {
     /usr/local/bin/mayapy2020 -m pip "$@";
 }
 export -f pip;
+
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/reference_scripts/sh_linux_env_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_env_launch/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -116,3 +133,7 @@ export -f pip;
 
 # Run the requested command
 pip
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/reference_scripts/sh_linux_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_launch/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -118,3 +135,7 @@ export -f pip;
 pip
 
 exit
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/reference_scripts/sh_linux_launch_args/hab_config.sh
+++ b/tests/reference_scripts/sh_linux_launch_args/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -118,3 +135,7 @@ export -f pip;
 as_str -c "print('Running...');import sys;print('sys', sys)"
 
 exit
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/reference_scripts/sh_win_activate/hab_config.sh
+++ b/tests/reference_scripts/sh_win_activate/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -112,3 +129,8 @@ function pip() {
     "C:\Program Files\Autodesk\Maya2020\bin\mayapy.exe" -m pip "$@";
 }
 export -f pip;
+
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/reference_scripts/sh_win_activate_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_win_activate_launch/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -116,3 +133,7 @@ export -f pip;
 
 # Run the requested command
 pip
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/reference_scripts/sh_win_env/hab_config.sh
+++ b/tests/reference_scripts/sh_win_env/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -112,3 +129,8 @@ function pip() {
     "C:\Program Files\Autodesk\Maya2020\bin\mayapy.exe" -m pip "$@";
 }
 export -f pip;
+
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/reference_scripts/sh_win_env_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_win_env_launch/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -116,3 +133,7 @@ export -f pip;
 
 # Run the requested command
 pip
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/reference_scripts/sh_win_launch/hab_config.sh
+++ b/tests/reference_scripts/sh_win_launch/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -118,3 +135,7 @@ export -f pip;
 pip
 
 exit
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit

--- a/tests/reference_scripts/sh_win_launch_args/hab_config.sh
+++ b/tests/reference_scripts/sh_win_launch_args/hab_config.sh
@@ -1,10 +1,27 @@
 # Customize the prompt
 export PS1="[not_set/child] $PS1"
 
-# Exit immediately if a command exits with a non-zero status.
-# This ensures that if any exit codes are encountered it gets propagated to
-# whatever originally called hab.
-set -e
+# ----- Exit Code propagation start -----
+# While this script is running, exit immediately if a command exits with a
+# non-zero status. This ensures that if any exit codes are encountered it gets
+# propagated to whatever originally called hab.
+if [[ $- == *e* ]]; then
+    errexit_was_enabled=true
+else
+    errexit_was_enabled=false
+    set -e
+fi
+
+# Function to reset errexit flag on exit.
+reset_errexit() {
+    if [[ "$errexit_was_enabled" == false ]]; then
+        set +e
+    fi
+}
+# Ensure reset_errexit is called when the script exits. This prevents hab from
+# changing the current setting of errexit outside of this hab script
+trap reset_errexit EXIT
+# ----- Exit Code propagation end -----
 
 # Setting global environment variables:
 unset UNSET_VARIABLE
@@ -118,3 +135,7 @@ export -f pip;
 as_str -c "print('Running...');import sys;print('sys', sys)"
 
 exit
+
+# Remove the `set -e` handling code
+trap - EXIT
+reset_errexit


### PR DESCRIPTION
Addresses #115

Prevent hab env from exiting if any errors happen in the child shell

The config.sh template now keeps track of if it needed to call `set -e` and ensures if so it is reverted before exiting the script even on error.

I'm unable to add automated testing so I've created some manual test scripts that guide testing of this feature. These should be run periodically.

The problem seems to be that when using subprocess run a hab launch command in bash doesn't work. All of the bash code works and its able to use hab to generate the .sh files, but it silently doesn't call the launched alias and doesn't error out either.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
