### PR TITLE
Update release ci to upload-artifact v4

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -31,12 +31,13 @@ jobs:
 
       # Upload the built pip packages so we can inspect them
       - name: Upload packages.
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pip-packages
           path: |
             dist/hab-*.whl
             dist/hab-*.tar.gz
+          # This is only used if there is a problem with the next step
           retention-days: 1
 
       - name: Publish to PyPI


### PR DESCRIPTION
Apparently I missed the upload-artifact in this file when updating python-static-analysis-and-test.yml. Copied from that file. I don't have a good way to pre-test this, but it should work.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [ ] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
