### PR TITLE
Better handling of disabled EntryPoints

### DIFF
--- a/.github/workflows/python-static-analysis-and-test.yml
+++ b/.github/workflows/python-static-analysis-and-test.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Run Tox
         run: |
-          tox -e begin,py-${{ matrix.pkg_mods }}
+          tox -e begin,py-${{ matrix.pkg_mods }} -- --tb short
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/hab/entry_points.py
+++ b/hab/entry_points.py
@@ -1,0 +1,38 @@
+from typing import Any, List
+
+from importlib_metadata import EntryPoint
+
+
+class EntryPointNull(EntryPoint):
+    """Represents a disabled entry point.
+
+    This is used in `Site.entry_points_for_group(..., omit_none=False)` to represent
+    a entry point being set to None/null. Otherwise the null entry point is omitted.
+
+    Example host.json:
+
+        {"append": {"entry_points": {"hab.cli": {"gui": null}}}}
+    """
+
+    def __init__(self, name: str, value: None, group: str) -> None:
+        # Keeping `value` argument to preserve compatibility
+        if value is not None:
+            raise ValueError("The value must be None.")
+
+        vars(self).update(name=name, value=None, group=group)
+
+    def load(self) -> Any:
+        return None
+
+    @property
+    def module(self) -> str:
+        return "builtins"
+
+    @property
+    def attr(self) -> str:
+        return ""
+
+    @property
+    def extras(self) -> List[str]:
+        # Note: Python 3.7 requires using `List[str]` from typing
+        return []

--- a/hab/site.py
+++ b/hab/site.py
@@ -241,10 +241,18 @@ class Site(UserDict):
         # using it's `entry_points` function. We want the current site configuration
         # to define the entry points being loaded not the installed pip packages.
         for name, value in ep_defs.items():
-            if omit_none and value is None:
+            if value is None:
+                if omit_none:
+                    continue
+
+                # If requested return a representation of the null entry point
+                from .entry_points import EntryPointNull
+
+                ep = EntryPointNull(name=name, value=None, group=group)
+                ret.append(ep)
                 continue
 
-            ep = EntryPoint(name=name, group=group, value=value)
+            ep = EntryPoint(name=name, value=value, group=group)
             ret.append(ep)
         return ret
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,20 +328,22 @@ class Helpers(object):
             check (pathlib.Path): Compare generated to this check file. It is
                 normally committed inside the hab/tests folder.
         """
-        check = check.open().readlines()
+        _check = check.open().readlines()
         cache = generated.open().readlines()
         # Add trailing white space to match template file's trailing white space
         cache[-1] += "\n"
         cache_len = len(cache)
-        check_len = len(check)
-        assert (
-            cache_len == check_len
-        ), f"Generated cache does not have the same number of lines as check: {generated}"
+        check_len = len(_check)
+        assert cache_len == check_len, (
+            "Generated cache does not have the same number of lines "
+            f'"{check.name}": "{generated}"'
+        )
 
         for i in range(len(cache)):
-            assert (
-                cache[i] == check[i]
-            ), f"Difference on line: {i} between the generated cache and {generated}."
+            assert cache[i] == _check[i], (
+                f"Difference in generated cache on line {i}: "
+                f'"{check.name}" -> "{generated}"'
+            )
 
     @staticmethod
     def render_template(template, dest, **kwargs):

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -650,6 +650,11 @@ class TestEntryPoints:
         assert ep.group == "hab.cli"
         if omit_none is False:
             assert ep.value is None
+            from hab.entry_points import EntryPointNull
+
+            # Verify that the custom subclass was returned.
+            assert isinstance(ep, EntryPointNull)
+
             # Noting else to test, we can't load a value of None.
             return
         else:
@@ -801,6 +806,27 @@ class TestEntryPoints:
         )
         assert instance.root == Path("b/root/path")
         assert instance.site is site
+
+    def test_null(self):
+        """Test misc implementation of `hab.entry_points.EntryPointNull`"""
+        from hab.entry_points import EntryPointNull
+
+        # For compatibility with the super class we are keeping the same args.
+        # However this class requires that you only pass None to value
+        with pytest.raises(ValueError, match="The value must be None."):
+            EntryPointNull("name", "value", "group")
+
+        # Verify class creation
+        ep = EntryPointNull("name", None, "group")
+        assert ep.group == "group"
+        assert ep.name == "name"
+        assert ep.value is None
+
+        # Ensure the various functions are tested for coverage
+        assert ep.load() is None
+        assert ep.module == "builtins"
+        assert ep.attr == ""
+        assert ep.extras == []
 
 
 class TestDownloads:

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
 commands =
     coverage erase
 
-[testenv:py{37,38,39,310,311}-{json,json5}]
+[testenv:py{37,38,39,310,311}-{json,json5,s3}]
 depends = begin
 
 [testenv:end]


### PR DESCRIPTION
`importlib-metadata==8.7.0` made it no longer possible to pass None to `EntryPoint` value. This creates a custom subclass to handle this edge case. Also improves testing suite.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [x] Bugfix (change that fixes an issue)
- [ ] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
