### PR TITLE
Easily resolve HAB_FREEZE when inside of that config

### DIFF
--- a/hab/resolver.py
+++ b/hab/resolver.py
@@ -5,6 +5,7 @@ import copy
 import enum
 import fnmatch
 import logging
+import os
 from contextlib import contextmanager
 
 import anytree
@@ -12,7 +13,7 @@ from packaging.requirements import Requirement
 
 from . import utils
 from .errors import HabError, InvalidRequirementError, _IgnoredVersionError
-from .parsers import Config, HabBase, StubDistroVersion
+from .parsers import Config, HabBase, StubDistroVersion, UnfrozenConfig
 from .site import Site
 from .solvers import Solver
 from .user_prefs import UserPrefs
@@ -567,15 +568,32 @@ class Resolver(object):
                     logger.debug(str(error))
         return forest
 
-    def resolve(self, uri, forced_requirements=None):
+    def resolve(self, uri=None, from_env=False, forced_requirements=None):
         """Find the closest configuration and reduce it into its final form.
 
         Args:
-            uri (str): The URI to resolve.
+            uri (str, optional): The URI to resolve.
+            from_env (bool, optional): If enabled return a `UnfrozenConfig` built
+                from the `HAB_FREEZE` environment variable if set. Otherwise
+                use the `HAB_PATHS` env variable if set and `uri` is None.
             forced_requirements (list, optional): A list of additional distro version
                 requirements to respect even if they are not specified in a config.
                 Has :py:meth:`hab.solvers.Solver.simplify_requirements` called on it.
         """
+        if from_env:
+            # If the HAB_FREEZE env var is set, just return it as a UnfrozenConfig
+            freeze = os.getenv("HAB_FREEZE")
+            if freeze:
+                return UnfrozenConfig(freeze, self)
+            # Otherwise if uri is not specified resolve the URI stored in HAB_URI
+            if uri is None:
+                uri = os.getenv("HAB_URI")
+                if uri is None:
+                    logger.warning(
+                        'The "HAB_FREEZE" or "HAB_URI" env vars are not defined, '
+                        "can't resolve from_env."
+                    )
+
         uri = self.uri_validate(uri)
         context = self.closest_config(uri)
         try:


### PR DESCRIPTION
This allows you to easily get a hab Config object for the hab config you are currently running inside of.

Currently you have to run this code:
```py
import os
import hab

default_uri = "a/uri"
freeze = os.getenv('HAB_FREEZE')
uri = os.getenv('HAB_URI', default_uri)
resolver = hab.Resolver.instance()
if freeze:
    cfg = hab.parsers.UnfrozenConfig(freeze, resolver)
else:
    cfg = resolver.resolve(uri)
```

This Pull Request allows you to replace that code with.
```py
resolver = hab.Resolver.instance()
cfg = resolver.resolve("a/uri", from_env=True)
```

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [ ] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [ ] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

## Proposed Changes

<!--
    Describe the big picture of your changes here to communicate to why this pull request has been made and should be accepted.
    If it fixes a bug or resolves a feature request, please be sure to link to that issue.
-->
