### PR TITLE
Add ability to filter dict keys in dumps based on verbosity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 ci:
   autoupdate_schedule: quarterly
-  skip: [black, flake8]
+  skip: [black, flake8, semgrep]
 
 repos:
 
@@ -31,6 +31,7 @@ repos:
       - id: end-of-file-fixer
       - id: requirements-txt-fixer
       - id: trailing-whitespace
+      - id: check-added-large-files
 
 -   repo: https://github.com/pycqa/isort
     rev: 6.1.0
@@ -39,15 +40,13 @@ repos:
         name: isort (python)
 
 -   repo: https://github.com/semgrep/pre-commit
-    # This version works with python 3.9+
-    rev: 'v1.136.0'
+    rev: 'v1.159.0'
     hooks:
       - id: semgrep
-        entry: semgrep
+        language_version: python3.11
         args: [
           '--config',
           'semgrep-json.yaml',
           '--error',
           '--skip-unknown-extensions',
-          '.'
         ]

--- a/README.md
+++ b/README.md
@@ -689,6 +689,61 @@ calling `hab cache` has all of the required `platform_path_maps` defined. The
 cache will replace the start of file paths matching one of the current platform's
 mapping values with the mappings key.
 
+#### Filtering dumps
+
+The cli's dump command can get pretty verbose, to give better control over this
+you can use the `dump_filters` key in your site config. This defaults to hiding
+some of the complexity in the site and alias output.
+
+See the site default in [hab/site.py](hab/site.py).
+```json5
+{
+    "dump_filters": {
+        // Filters for the site dump
+        "site": {
+            // For verbosity 0 and 1, don't show these items
+            "0": [
+                "dump_filters",
+                "ignored_distros",
+                "platforms"
+            ],
+            // For verbosity 2, show all items but dump_filters
+            "2": ["dump_filters"]
+            // Any higher verbosity will show all items
+        },
+        // Filters for alias dump
+        "alias": {...}
+    }
+}
+```
+
+Each key in `dump_filters` is targeting a specific dump filter. "alias" is used
+to filter the output of aliases (`hab dump - -vvv`), and site controls the site
+dump's items (`hab dump -t s -vvv`). For each of these dicts, the key is a int
+representing the verbosity level. `-vv` is `"2"`, `-vvvvv` is `"5"`. The value
+is a list of key names to hide. When there is a gap in verbosity numbers it will
+use the closest verbosity filter <= the requested verbosity. If the verbosity is
+higher than the largest defined verbosity, no filtering will happen.
+
+These commands show the differences by adding extra verbosity for a site dump:
+```bash
+$ cd tests
+$ hab --site site/site_dump_filter.json --site site_main.json dump -t s
+$ hab --site site/site_dump_filter.json --site site_main.json dump -t s -v
+...
+$ hab --site site/site_dump_filter.json --site site_main.json dump -t s -vvvvv
+```
+
+Similarly you can filter the text shown for alias by specifying `dump_filters["alias"]`.
+Config dumps only start to show filterable keys for aliases at verbosity 3+ there
+is no need to specify lower numbers.
+
+```bash
+$ cd tests
+$ hab --site "site_main.json" dump app/aliased -vvv
+$ hab --site "site_main.json" dump app/aliased -vvvv
+```
+
 ### Python version
 
 Hab uses shell script files instead of an entry_point executable. This allows it

--- a/hab/cli.py
+++ b/hab/cli.py
@@ -646,7 +646,7 @@ def env(settings, uri, launch):
     "--verbose",
     "verbosity",
     count=True,
-    help="Show increasingly detailed output. Can be used up to 3 times.",
+    help="Show increasingly detailed output.",
 )
 @click.option(
     "-f",

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -401,9 +401,15 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
             elif prop == "versions":
                 value = self._dump_versions(value, verbosity=verbosity, color=color)
 
+            # Hide some of the alias keys depending on the selected verbosity
+            exclude = self.resolver.site.dump_filter("alias", verbosity)
             ret.append(
                 utils.dump_object(
-                    value, label=f"{prop}:  ", flat_list=flat_list, color=color
+                    value,
+                    label=f"{prop}:  ",
+                    flat_list=flat_list,
+                    color=color,
+                    exclude=exclude,
                 )
             )
 

--- a/hab/site.py
+++ b/hab/site.py
@@ -1,3 +1,4 @@
+import bisect
 import copy
 import logging
 import os
@@ -36,6 +37,28 @@ class Site(UserDict):
             "ignored_distros": ["release", "pre"],
             "platforms": ["windows", "osx", "linux"],
             "site_cache_file_template": ["{{stem}}.habcache"],
+            "dump_filters": {
+                "alias": {
+                    "3": [
+                        "defines_aliases",
+                        "distro",
+                        "icon",
+                        "min_verbosity",
+                        "sources",
+                    ]
+                },
+                "site": {
+                    "0": [
+                        "dump_filters",
+                        "ignored_distros",
+                        "platforms",
+                        "prefs_default",
+                        "site_cache_file_template",
+                        "verbosity_action",
+                    ],
+                    "2": ["dump_filters"],
+                },
+            },
         }
     }
 
@@ -44,6 +67,7 @@ class Site(UserDict):
             platform = utils.Platform.name()
         self.platform = platform
         self._downloads_parsed = False
+        self._dump_filters_cache = {}
 
         # Add default data to all site instances. Site data is only valid for
         # the current platform, so discard any other platform configurations.
@@ -166,6 +190,9 @@ class Site(UserDict):
         # Include all of the resolved site configurations
         ret = []
         for prop, value in self.items():
+            # Hide some properties depending on the selected verbosity
+            if prop in self.dump_filter("site", verbosity):
+                continue
             if verbosity and prop in ("config_paths", "distro_paths"):
                 cache = getattr(self.cache, prop)()
                 paths = []
@@ -185,6 +212,32 @@ class Site(UserDict):
 
         ret = "\n".join(ret)
         return utils.dump_title("Dump of Site", f"{site_ret}\n{ret}", color=color)
+
+    def dump_filter(self, target, verbosity):
+        """Returns the requested filter <= to the requested verbosity level.
+
+        The returned list of key names is used by various dump methods to filter
+        how much data they show. When showing a target dict, it will hide the
+        items stored in this list for the verbosity level.
+        """
+        sorted_keys = self._dump_filters_cache.get(target)
+        if not sorted_keys:
+            return []
+
+        # Don't filter anything if larger than the largest defined verbosity
+        if verbosity > sorted_keys[-1]:
+            return []
+
+        # Find the insertion point for the verbosity threshold
+        idx = bisect.bisect_right(sorted_keys, verbosity)
+
+        # Verbosity is lower than the smallest available filter level
+        if idx == 0:
+            return []
+
+        # Retrieve the correct key and return the associated list
+        target_verbosity = sorted_keys[idx - 1]
+        return self.data["dump_filters"][target][target_verbosity]
 
     def entry_point_init(self, group, value, args, name=""):
         """Initialize an entry point with args and kwargs.
@@ -311,6 +364,9 @@ class Site(UserDict):
 
         self["distro_paths"] = distro_paths
 
+        # Standardize and cache dump_filters
+        self.standardize_dump_filters()
+
         # Ensure any platform_path_maps are converted to pathlib objects.
         self.standardize_platform_path_maps()
 
@@ -422,6 +478,32 @@ class Site(UserDict):
             logger.debug(f"Running {group} entry_point: {ep}")
             func = ep.load()
             func(**kwargs)
+
+    def standardize_dump_filters(self):
+        """Conforms dump_filter and caches data to ensure dump_filter() is fast.
+
+        Rebuilds "dump_filters" converting the verbosity keys to int. Populates
+        the _dump_filters_cache used by dump_filter().
+        """
+        dump_filters = self.data.get("dump_filters", {})
+
+        for target, verbosity_filter in dump_filters.items():
+            standardized_flter = {}
+            for k, v in verbosity_filter.items():
+                # Convert the key to an int value for later use and check for
+                # invalid configuration.
+                try:
+                    standardized_flter[int(k)] = v
+                except ValueError:
+                    raise ValueError(
+                        f"dump_filter's verbosity keys must be an int, got: {k!r} for {v}"
+                    ) from None
+
+            # Update from str to int keys
+            dump_filters[target] = standardized_flter
+
+            # Store the cache for repeated bisect calls
+            self._dump_filters_cache[target] = sorted(standardized_flter.keys())
 
     def standardize_platform_path_maps(self):
         """Ensure the mappings defined in platform_path_maps are converted to

--- a/hab/utils.py
+++ b/hab/utils.py
@@ -132,7 +132,9 @@ def decode_freeze(txt):
     return json.loads(data)
 
 
-def dump_object(obj, label="", width=80, flat_list=False, color=False, verbosity=0):
+def dump_object(
+    obj, label="", width=80, flat_list=False, color=False, verbosity=0, exclude=None
+):
     """Recursively convert python objects into a human readable table string.
 
     Args:
@@ -152,6 +154,8 @@ def dump_object(obj, label="", width=80, flat_list=False, color=False, verbosity
         color (bool, optional): Use ANSI escape character sequences to colorize
             the output of the text.
         verbosity (int, optional): More information is shown with higher values.
+        exclude (list, optional): A list of dict keys to exclude from the output.
+            This is how `Site.dump_filter()` gets applied.
     """
     pad = " " * len(label)
     if label:
@@ -165,7 +169,12 @@ def dump_object(obj, label="", width=80, flat_list=False, color=False, verbosity
         rows = []
         obj = [
             dump_object(
-                o, width=width, flat_list=flat_list, color=color, verbosity=verbosity
+                o,
+                width=width,
+                flat_list=flat_list,
+                color=color,
+                verbosity=verbosity,
+                exclude=exclude,
             )
             for o in obj
         ]
@@ -200,6 +209,8 @@ def dump_object(obj, label="", width=80, flat_list=False, color=False, verbosity
         rows = []
         lbl = label
         for k, v in sorted(obj.items()):
+            if exclude and k in exclude:
+                continue
             rows.append(
                 dump_object(
                     v,
@@ -208,6 +219,7 @@ def dump_object(obj, label="", width=80, flat_list=False, color=False, verbosity
                     flat_list=flat_list,
                     color=color,
                     verbosity=verbosity,
+                    exclude=exclude,
                 )
             )
             lbl = pad

--- a/tests/site/site_dump_filter.json
+++ b/tests/site/site_dump_filter.json
@@ -1,0 +1,32 @@
+{
+    "set": {
+        "dump_filters": {
+            "site": {
+                "0": [
+                    "config_paths",
+                    "distro_paths",
+                    "downloads",
+                    "dump_filters",
+                    "ignored_distros",
+                    "platform_path_maps",
+                    "platforms",
+                    "site_cache_file_template",
+                    "stub_distros"
+                ],
+                "2": [
+                    "downloads",
+                    "dump_filters",
+                    "entry_points",
+                    "filename",
+                    "platform_path_maps",
+                    "platforms"
+                ],
+                "4": [
+                    "dump_filters",
+                    "platform_path_maps",
+                    "platforms"
+                ]
+            }
+        }
+    }
+}

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -545,6 +545,23 @@ class TestDump:
             else:
                 assert "stub_distros:" in result
 
+    def test_filters(self, habcached_resolver):
+        """Check that dump properly respects dump_filters["alias"] site settings."""
+        # Verify that the expected test data is set. There is at least a 3 verbosity setting.
+        assert set(habcached_resolver.site["dump_filters"]["alias"].keys()) == set([3])
+
+        cfg = habcached_resolver.resolve("not_set/child")
+        checks = ["distro:  ('aliased', '2.0')", "distro:  ('maya2020', '2020.1')"]
+
+        # At verbosity 3 distro is not shown
+        result = cfg.dump(verbosity=3, color=False)
+        for check in checks:
+            assert result.count(check) == 0
+        # At verbosity 4 distro starts showing
+        result = cfg.dump(verbosity=4, color=False)
+        for check in checks:
+            assert result.count(check) == 5
+
 
 def test_environment(resolver):
     # Check that the correct errors are raised

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import tempfile
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -246,105 +247,209 @@ def test_path_in_raise(config_root):
     assert "missing_file.json" in str(excinfo.value)
 
 
-def test_dump(config_root):
-    """utils.dump_object are checked pretty well in test_parsing, here we test
-    the colorization settings and ensuring that the desired results are listed
-    """
-    checks = (
-        "{green}Dump of Site{reset}\n",
-        "{green}ignored_distros:  {reset}release, pre",
-    )
+class TestDump:
+    def test_dump(self, config_root):
+        """utils.dump_object are checked pretty well in test_parsing, here we test
+        the colorization settings and ensuring that the desired results are listed
+        """
+        checks = (
+            "{green}Dump of Site{reset}\n",
+            "{green}filename:  {reset}{fn}",
+            "{green}stub_distros:  {reset}Dictionary keys: 0",
+            "{green}downloads:  {reset}Dictionary keys: 2",
+        )
 
-    paths = [config_root / "site_main.json"]
-    site = Site(paths)
-    assert site.get("colorize") is None
+        paths = [config_root / "site_main.json"]
+        site = Site(paths)
+        assert site.get("colorize") is None
 
-    result = site.dump()
-    for check in checks:
-        assert check.format(green=Fore.GREEN, reset=Style.RESET_ALL) in result
+        result = site.dump()
+        for check in checks:
+            c = check.format(
+                green=Fore.GREEN, reset=Style.RESET_ALL, fn="site_main.json"
+            )
+            assert c in result
 
-    paths = [config_root / "site_override.json"]
-    site = Site(paths)
-    assert site.get("colorize") is False
+        paths = [config_root / "site_override.json"]
+        site = Site(paths)
+        assert site.get("colorize") is False
 
-    result = site.dump()
-    for check in checks:
-        assert check.format(green="", reset="") in result
+        result = site.dump()
+        for check in checks:
+            c = check.format(green="", reset="", fn="site_override.json")
+            assert c in result
 
+    def test_cached(self, config_root, habcached_site_file):
+        """Test that cached indicators are shown properly for site dump based on
+        verbosity setting."""
 
-def test_dump_cached(config_root, habcached_site_file):
-    """Test that cached indicators are shown properly for site dump based on
-    verbosity setting."""
+        # Create the hab setup with caching only on one of the two site files
+        other_site = config_root / "site_os_specific.json"
+        site = Site([habcached_site_file, other_site])
+        resolver = Resolver(site)
+        site.cache.save_cache(resolver, habcached_site_file)
 
-    # Create the hab setup with caching only on one of the two site files
-    other_site = config_root / "site_os_specific.json"
-    site = Site([habcached_site_file, other_site])
-    resolver = Resolver(site)
-    site.cache.save_cache(resolver, habcached_site_file)
+        # Build a check string to verify that the dump is correctly formatted
+        # Note: To simplify the check_template for testing we will force the dump
+        # to a smaller width to ensure it always wraps the file paths.
+        platform = utils.Platform.name()
+        check_template = (
+            f"{{green}}HAB_PATHS:  {{reset}}{habcached_site_file}{{cached}}",
+            f"            {other_site}",
+            f"{{green}}config_paths:  {{reset}}config\\path\\{platform}",
+            f"               {config_root}\\configs\\*{{cached}}",
+            f"{{green}}distro_paths:  {{reset}}distro\\path\\{platform}{{cls_name}}",
+            f"               {config_root}\\distros\\*{{cls_name}}{{cached}}",
+        )
+        check_template = "\n".join(check_template)
+        colors = {
+            "green": Fore.GREEN,
+            "reset": Style.RESET_ALL,
+        }
+        if platform != "windows":
+            check_template = check_template.replace("\\", "/")
 
-    # Build a check string to verify that the dump is correctly formatted
-    # Note: To simplify the check_template for testing we will force the dump
-    # to a smaller width to ensure it always wraps the file paths.
-    platform = utils.Platform.name()
-    check_template = (
-        f"{{green}}HAB_PATHS:  {{reset}}{habcached_site_file}{{cached}}",
-        f"            {other_site}",
-        f"{{green}}config_paths:  {{reset}}config\\path\\{platform}",
-        f"               {config_root}\\configs\\*{{cached}}",
-        f"{{green}}distro_paths:  {{reset}}distro\\path\\{platform}{{cls_name}}",
-        f"               {config_root}\\distros\\*{{cls_name}}{{cached}}",
-    )
-    check_template = "\n".join(check_template)
-    colors = {
-        "green": Fore.GREEN,
-        "reset": Style.RESET_ALL,
-    }
-    if platform != "windows":
-        check_template = check_template.replace("\\", "/")
+        # With color enabled:
+        # No verbosity, should not show cached status
+        assert site.get("colorize") is None
+        result = site.dump(width=60)
+        check = check_template.format(cached="", cls_name="", **colors)
+        assert check in result
 
-    # With color enabled:
-    # No verbosity, should not show cached status
-    assert site.get("colorize") is None
-    result = site.dump(width=60)
-    check = check_template.format(cached="", cls_name="", **colors)
-    assert check in result
+        # verbosity enabled, should show cached status
+        result = site.dump(verbosity=1, width=60)
+        check = check_template.format(
+            cached=f" {Fore.YELLOW}(cached){Style.RESET_ALL}", cls_name="", **colors
+        )
+        assert check in result
 
-    # verbosity enabled, should show cached status
-    result = site.dump(verbosity=1, width=60)
-    check = check_template.format(
-        cached=f" {Fore.YELLOW}(cached){Style.RESET_ALL}", cls_name="", **colors
-    )
-    assert check in result
+        # verbosity level 2, should also show DistroFinder classes
+        result = site.dump(verbosity=2, width=60)
+        check = check_template.format(
+            cached=f" {Fore.YELLOW}(cached){Style.RESET_ALL}",
+            cls_name=f" {Fore.CYAN}[DistroFinder]{Style.RESET_ALL}",
+            **colors,
+        )
+        assert check in result
 
-    # verbosity level 2, should also show DistroFinder classes
-    result = site.dump(verbosity=2, width=60)
-    check = check_template.format(
-        cached=f" {Fore.YELLOW}(cached){Style.RESET_ALL}",
-        cls_name=f" {Fore.CYAN}[DistroFinder]{Style.RESET_ALL}",
-        **colors,
-    )
-    assert check in result
+        # Disable Color:
+        site["colorize"] = False
+        assert site.get("colorize") is False
 
-    # Disable Color:
-    site["colorize"] = False
-    assert site.get("colorize") is False
+        # No verbosity, should not show cached status
+        result = site.dump(width=60)
+        check = check_template.format(cached="", green="", reset="", cls_name="")
+        assert check in result
 
-    # No verbosity, should not show cached status
-    result = site.dump(width=60)
-    check = check_template.format(cached="", green="", reset="", cls_name="")
-    assert check in result
+        # verbosity enabled, should show cached status
+        result = site.dump(verbosity=1, width=60)
+        check = check_template.format(
+            cached=" (cached)", green="", reset="", cls_name=""
+        )
+        assert check in result
 
-    # verbosity enabled, should show cached status
-    result = site.dump(verbosity=1, width=60)
-    check = check_template.format(cached=" (cached)", green="", reset="", cls_name="")
-    assert check in result
+        # verbosity level 2, should also show DistroFinder classes
+        result = site.dump(verbosity=2, width=60)
+        check = check_template.format(
+            cached=" (cached)", green="", reset="", cls_name=" [DistroFinder]"
+        )
+        assert check in result
 
-    # verbosity level 2, should also show DistroFinder classes
-    result = site.dump(verbosity=2, width=60)
-    check = check_template.format(
-        cached=" (cached)", green="", reset="", cls_name=" [DistroFinder]"
-    )
-    assert check in result
+    def test_filters(self, config_root, tmp_path):
+        """Check that dump properly respects dump_filters["site"] site settings."""
+        paths = [
+            config_root / "site_main.json",
+            config_root / "site" / "site_dump_filter.json",
+        ]
+        site = Site(paths)
+
+        # Verify that the expected test data is set.
+        assert set(site["dump_filters"]["site"].keys()) == set([0, 2, 4])
+
+        # Verify that a empty list is returned if requesting a undefined target.
+        assert "undefined" not in site["dump_filters"]
+        assert site.dump_filter("undefined", 0) == []
+        assert site.dump_filter("undefined", 1) == []
+        assert site.dump_filter("undefined", 9) == []
+
+        def check_verbosity(verbosity, checks):
+            """Verify that dump_filters is respected for site"""
+            result = site.dump(verbosity=verbosity, color=False)
+            try:
+                for check in checks.values():
+                    if check[0]:
+                        assert (
+                            check[1] in result
+                        ), f"{check[1]!r} should be in dump for verbosity {verbosity}"
+                    else:
+                        assert (
+                            check[1] not in result
+                        ), f"{check[1]!r} should not be in dump for verbosity {verbosity}"
+            except Exception:
+                print(result)
+                raise
+
+        checks = {
+            "hab": [True, "HAB_PATHS:  "],
+            "config": [False, "config_paths:  "],
+            "distro": [False, "distro_paths:  "],
+            "stub": [False, "stub_distros:"],
+            "ignore": [False, "ignored_distros:  release, pre"],
+            "platforms": [False, "platforms:  windows, linux"],
+            "cache": [False, "site_cache_file_template:  {stem}.habcache"],
+            "dump_filters": [False, "dump_filters:"],
+            "generic": [True, "generic_value:  False"],
+            "filename": [True, "filename:  site_main.json"],
+            "plat_map": [False, "platform_path_maps:"],
+            "download": [False, "downloads:"],
+        }
+
+        check_verbosity(0, checks)
+        check_verbosity(1, checks)
+        # Filename is only hidden for verbosity 2-3
+        checks["filename"][0] = False
+        # These are now being shown
+        checks["config"][0] = True
+        checks["distro"][0] = True
+        checks["stub"][0] = True
+        checks["ignore"][0] = True
+        checks["cache"][0] = True
+        check_verbosity(2, checks)
+        check_verbosity(3, checks)
+        # Filename is only hidden for verbosity 2-3
+        checks["filename"][0] = True
+        # These are now being shown
+        checks["download"][0] = True
+        check_verbosity(4, checks)
+        # Everything should be shown
+        for check in checks.values():
+            check[0] = True
+        check_verbosity(5, checks)
+
+    def test_filters_invalid(self, config_root, tmp_path):
+        """Tests handling of invalid verbosity keys."""
+
+        # Create a invalid site file
+        site_file = tmp_path / "invalid.json"
+        invalid = {
+            "set": {
+                "dump_filters": {
+                    "site": {
+                        # These keys must be convertible to ints. A ValueError
+                        # will be raised when processing this file.
+                        "a": ["dump_filters"]
+                    }
+                }
+            }
+        }
+        with site_file.open("w") as fh:
+            json.dump(invalid, fh)
+
+        with pytest.raises(
+            ValueError,
+            match="dump_filter's verbosity keys must be an int, got: 'a' for",
+        ):
+            Site([site_file])
 
 
 class TestOsSpecific:

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,8 @@ commands =
     coverage run -m pytest {tty:--color=yes} {posargs:tests/}
 
 [testenv:begin]
+labels = fulltest
+description = Clean up files generated py previous test runs.
 basepython = python3
 deps =
     coverage[toml]
@@ -39,9 +41,15 @@ commands =
     coverage erase
 
 [testenv:py{37,38,39,310,311,312,313}-{json,json5,s3}]
+labels =
+    test
+    fulltest
+description = Run pytest for {envname}
 depends = begin
 
 [testenv:end]
+labels = fulltest
+description = Generate coverage for previously run tests.
 basepython = python3
 depends =
     begin
@@ -54,13 +62,17 @@ commands =
     coverage report
 
 [testenv:black]
+labels = lint
+description = Run black checks on the code, (BLACK_ARGS)
 basepython = python3
 deps =
     black==22.12.0
 commands =
-    black . --check
+    black {env:BLACK_ARGS:. --check}
 
 [testenv:flake8]
+labels = lint
+description = Run flake8 checks on the code, (FLAKE8_ARGS)
 basepython = python3
 deps =
     flake8-bugbear==22.12.6
@@ -68,9 +80,11 @@ deps =
     flake8==5.0.4
     pep8-naming==0.13.3
 commands =
-    flake8 .
+    flake8 {env:FLAKE8_ARGS:.}
 
 [testenv:semgrep]
+labels = lint
+description = Run semgrep checks on the code, (SEMGREP_ARGS)
 deps = semgrep
 commands =
-    semgrep --config semgrep-json.yaml .
+    semgrep --config semgrep-json.yaml {env:SEMGREP_ARGS:.}

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,7 @@ commands =
 [testenv:semgrep]
 labels = lint
 description = Run semgrep checks on the code, (SEMGREP_ARGS)
-deps = semgrep
+basepython = python3.11
+deps = semgrep==1.159.0
 commands =
     semgrep --config semgrep-json.yaml {env:SEMGREP_ARGS:.}


### PR DESCRIPTION
Improvements to the tox config and adds ability to filter dicts in dumps.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [X] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)

The cli's dump command can get pretty verbose, to give better control over this
you can use the `dump_filters` key in your site config. This defaults to hiding
some of the complexity in the site and alias output.

See the site default in [hab/site.py](hab/site.py).
```json5
{
    "dump_filters": {
        // Filters for the site dump
        "site": {
            // For verbosity 0 and 1, don't show these items
            "0": [
                "dump_filters",
                "ignored_distros",
                "platforms"
            ],
            // For verbosity 2, show all items but dump_filters
            "2": ["dump_filters"]
            // Any higher verbosity will show all items
        },
        // Filters for alias dump
        "alias": {...}
    }
}
```

# Details

Each key in `dump_filters` is targeting a specific dump filter. "alias" is used
to filter the output of aliases (`hab dump - -vvv`), and site controls the site
dump's items (`hab dump -t s -vvv`). For each of these dicts, the key is a int
representing the verbosity level. `-vv` is `"2"`, `-vvvvv` is `"5"`. The value
is a list of key names to hide. When there is a gap in verbosity numbers it will
use the closest verbosity filter <= the requested verbosity. If the verbosity is
higher than the largest defined verbosity, no filtering will happen.

These commands show the differences by adding extra verbosity for a site dump:
```bash
$ cd tests
$ hab --site site/site_dump_filter.json --site site_main.json dump -t s
$ hab --site site/site_dump_filter.json --site site_main.json dump -t s -v
...
$ hab --site site/site_dump_filter.json --site site_main.json dump -t s -vvvvv
```

Similarly you can filter the text shown for alias by specifying `dump_filters["alias"]`.
Config dumps only start to show filterable keys for aliases at verbosity 3+ there
is no need to specify lower numbers.

```bash
$ cd tests
$ hab --site "site_main.json" dump app/aliased -vvv
$ hab --site "site_main.json" dump app/aliased -vvvv
```