### PR TITLE
Add source tracking to the distro info on alias dicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1085,9 +1085,9 @@ require multiple arguments, for more details see args documentation in
 [subprocess.Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen).
 
 When the aliases are converted to dicts, they automatically get a "distro" key
-added to them. This contains a two item tuple containing the `distro_name` and
-`version`. This is preserved when frozen. You can use this to track down what
-distro created a [duplicate alias](#duplicate-definitions). This is also useful
+added to them. This contains a three item tuple containing the `distro_name`,
+`version` and `source`. This is preserved when frozen. You can use this to track
+down what distro created a [duplicate alias](#duplicate-definitions). This is also useful
 if you need to tie a farm job to a specific version of a dcc based on the active
 hab setup.
 ```py

--- a/hab/parsers/distro_version.py
+++ b/hab/parsers/distro_version.py
@@ -148,7 +148,7 @@ class DistroVersion(HabBase):
         if aliases is NotSet:
             return aliases
 
-        version_info = (self.distro_name, str(self.version))
+        version_info = (self.distro_name, str(self.version), None)
         for platform in aliases.values():
             for alias in platform:
                 # Ensure that we always have a dictionary for aliases

--- a/hab/parsers/hab_base.py
+++ b/hab/parsers/hab_base.py
@@ -536,7 +536,7 @@ class HabBase(anytree.NodeMixin, metaclass=HabMeta):
                 )
                 for k, v in value.items()
             }
-        elif isinstance(value, (bool, int)):
+        elif isinstance(value, (bool, int)) or value is None:
             # Just return boolean values, no need to format
             return value
 

--- a/tests/frozen.json
+++ b/tests/frozen.json
@@ -50,21 +50,21 @@
     "windows": {
       "dcc": {
         "cmd": "TEST_DIR_NAME\\the_dcc.exe",
-        "distro": ["the_dcc", "1.2"]
+        "distro": ["the_dcc", "1.2", null]
       },
       "dcc1.2": {
         "cmd": "TEST_DIR_NAME\\the_dcc.exe",
-        "distro": ["the_dcc", "1.2"]
+        "distro": ["the_dcc", "1.2", null]
       }
     },
     "linux": {
       "dcc": {
         "cmd": "TEST_DIR_NAME//the_dcc",
-        "distro": ["the_dcc", "1.2"]
+        "distro": ["the_dcc", "1.2", null]
       },
       "dcc1.2": {
         "cmd": "TEST_DIR_NAME//the_dcc",
-        "distro": ["the_dcc", "1.2"]
+        "distro": ["the_dcc", "1.2", null]
       }
     }
   },

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -551,7 +551,10 @@ class TestDump:
         assert set(habcached_resolver.site["dump_filters"]["alias"].keys()) == set([3])
 
         cfg = habcached_resolver.resolve("not_set/child")
-        checks = ["distro:  ('aliased', '2.0')", "distro:  ('maya2020', '2020.1')"]
+        checks = [
+            "distro:  ('aliased', '2.0', None)",
+            "distro:  ('maya2020', '2020.1', None)",
+        ]
 
         # At verbosity 3 distro is not shown
         result = cfg.dump(verbosity=3, color=False)


### PR DESCRIPTION
This changes from `(distro_name, version)` to `(distro_name, version, source)`. Source is used to keep track of how defined_aliases are created, see the defines_aliases feature in following commit.

## Checklist

<!--
    Place an `x` in the boxes you have addressed. You can also fill these out after creating the Pull Request. If you're unsure about any of them, don't hesitate to ask. This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I formatted my changes with [black](https://github.com/psf/black)
- [x] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation regarding my changes where necessary
- [x] Any pre-existing tests continue to pass
- [x] Additional tests were made covering my changes

## Types of Changes

<!--
    Place an `x` in the box that applies.
-->

- [ ] Bugfix (change that fixes an issue)
- [x] New Feature (change that adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
